### PR TITLE
Add ui schemas for styling form elements

### DIFF
--- a/src/components/ui_schemas/analysis.json
+++ b/src/components/ui_schemas/analysis.json
@@ -1,0 +1,8 @@
+{
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 5
+    }
+  }
+}

--- a/src/components/ui_schemas/dataset.json
+++ b/src/components/ui_schemas/dataset.json
@@ -1,0 +1,11 @@
+{
+  "datasetType": {
+    "ui:widget": "checkboxes"
+  },
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 10
+    }
+  }
+}

--- a/src/components/ui_schemas/experiment.json
+++ b/src/components/ui_schemas/experiment.json
@@ -1,0 +1,21 @@
+{
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 5
+    }
+  },
+  "desgin": {
+    "sampleRef": {},
+    "libraryDescriptor": {
+      "targetLoci": {
+        "description": {
+          "ui:widget": "textarea",
+          "ui:options": {
+            "rows": 5
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/ui_schemas/policy.json
+++ b/src/components/ui_schemas/policy.json
@@ -1,0 +1,10 @@
+{
+  "policy": {
+    "policyText": {
+      "ui:widget": "textarea",
+      "ui:options": {
+        "rows": 10
+      }
+    }
+  }
+}

--- a/src/components/ui_schemas/run.json
+++ b/src/components/ui_schemas/run.json
@@ -1,0 +1,8 @@
+{
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 5
+    }
+  }
+}

--- a/src/components/ui_schemas/sample.json
+++ b/src/components/ui_schemas/sample.json
@@ -1,0 +1,8 @@
+{
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 5
+    }
+  }
+}

--- a/src/components/ui_schemas/study.json
+++ b/src/components/ui_schemas/study.json
@@ -1,0 +1,8 @@
+{
+  "studyDescription": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 5
+    }
+  }
+}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Basic styling of the forms. Could not figure out how to get DAC to accept only one main contact

### Related issues

<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1 add ui styling for schemas from: https://github.com/CSCfi/metadata-submitter/pull/92

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

Although tested manually

### Mentions

<!-- Shout outs to your friends that you made this happen or need help. -->
