### PR TITLE
Feature/folder backend check

### DIFF
--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -7,9 +7,7 @@ import DialogActions from "@material-ui/core/DialogActions"
 import DialogContent from "@material-ui/core/DialogContent"
 import DialogContentText from "@material-ui/core/DialogContentText"
 import DialogTitle from "@material-ui/core/DialogTitle"
-import Link from "@material-ui/core/Link"
 import { useSelector } from "react-redux"
-import { Link as RouterLink } from "react-router-dom"
 
 /*
  * Dialog contents are rendered based on parent component location and alert type
@@ -79,11 +77,14 @@ const CancelFormDialog = ({
               <Button variant="outlined" onClick={() => handleDialog(false)} color="primary" autoFocus>
                 No, continue creating the folder
               </Button>
-              <Link component={RouterLink} aria-label="Cancel a new folder and move to frontpage" to="/home">
-                <Button variant="contained" onClick={() => handleDialog(true)} color="primary">
-                  Yes, cancel creating folder
-                </Button>
-              </Link>
+              <Button
+                variant="contained"
+                aria-label="Cancel a new folder and move to frontpage"
+                onClick={() => handleDialog(true)}
+                color="primary"
+              >
+                Yes, cancel creating folder
+              </Button>
             </DialogActions>
           )
           break
@@ -93,11 +94,14 @@ const CancelFormDialog = ({
           dialogContent = "Folder has been saved"
           dialogActions = (
             <DialogActions style={{ justifyContent: "center" }}>
-              <Link component={RouterLink} aria-label="Save a new folder and move to frontpage" to="/home">
-                <Button variant="contained" onClick={() => handleDialog(true)} color="primary">
-                  Return to homepage
-                </Button>
-              </Link>
+              <Button
+                variant="contained"
+                aria-label="Save a new folder and move to frontpage"
+                onClick={() => handleDialog(true)}
+                color="primary"
+              >
+                Return to homepage
+              </Button>
             </DialogActions>
           )
           break
@@ -107,11 +111,14 @@ const CancelFormDialog = ({
           dialogContent = "Objects in this folder will be published"
           dialogActions = (
             <DialogActions style={{ justifyContent: "center" }}>
-              <Link component={RouterLink} aria-label="Publish folder contents and move to frontpage" to="/home">
-                <Button variant="contained" onClick={() => handleDialog(true)} color="primary">
-                  Publish
-                </Button>
-              </Link>
+              <Button
+                variant="contained"
+                aria-label="Publish folder contents and move to frontpage"
+                onClick={() => handleDialog(true)}
+                color="primary"
+              >
+                Publish
+              </Button>
             </DialogActions>
           )
           break

--- a/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
@@ -5,7 +5,9 @@ import Button from "@material-ui/core/Button"
 import Link from "@material-ui/core/Link"
 import { makeStyles } from "@material-ui/core/styles"
 import { useDispatch, useSelector } from "react-redux"
-import { Link as RouterLink } from "react-router-dom"
+import { useHistory, Link as RouterLink } from "react-router-dom"
+
+import WizardStatusMessageHandler from "../WizardForms/WizardStatusMessageHandler"
 
 import WizardAlert from "./WizardAlert"
 
@@ -49,21 +51,42 @@ const WizardFooter = () => {
   const folder = useSelector(state => state.submissionFolder)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [alertType, setAlertType] = useState("")
+  const [connError, setConnError] = useState(false)
+  const [responseError, setResponseError] = useState({})
+  const [errorPrefix, setErrorPrefix] = useState("")
+  let history = useHistory()
+
+  const resetDispatch = () => {
+    history.push("/home")
+    dispatch(resetWizard())
+    dispatch(resetObjectType())
+    dispatch(resetFolder())
+  }
 
   const handleAlert = alertWizard => {
+    setConnError(false)
     if (alertWizard && alertType === "cancel") {
-      dispatch(resetWizard())
-      dispatch(resetObjectType())
       dispatch(deleteFolderAndContent(folder))
+        .then(() => resetDispatch())
+        .catch(error => {
+          setConnError(true)
+          setResponseError(JSON.parse(error.response))
+          setErrorPrefix(error.message)
+        })
     } else if (alertWizard && alertType === "save") {
-      dispatch(resetWizard())
-      dispatch(resetFolder())
+      resetDispatch()
     } else if (alertWizard && alertType === "publish") {
-      dispatch(resetWizard())
       dispatch(publishFolderContent(folder))
+        .then(() => resetDispatch())
+        .catch(error => {
+          setConnError(true)
+          setResponseError(JSON.parse(error))
+          setErrorPrefix(`Couldn't publish folder with id ${folder.id}`)
+        })
     } else {
       setDialogOpen(false)
     }
+    setDialogOpen(false)
   }
 
   return (
@@ -121,6 +144,9 @@ const WizardFooter = () => {
         )}
       </div>
       {dialogOpen && <WizardAlert onAlert={handleAlert} parentLocation="footer" alertType={alertType}></WizardAlert>}
+      {connError && (
+        <WizardStatusMessageHandler successStatus="error" response={responseError} prefixText={errorPrefix} />
+      )}
     </div>
   )
 }

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
@@ -10,6 +10,8 @@ import { makeStyles } from "@material-ui/core/styles"
 import ClearIcon from "@material-ui/icons/Clear"
 import { useSelector, useDispatch } from "react-redux"
 
+import WizardStatusMessageHandler from "../WizardForms/WizardStatusMessageHandler"
+
 import { deleteObjectFromFolder } from "features/wizardSubmissionFolderSlice"
 
 const useStyles = makeStyles(theme => ({
@@ -66,10 +68,19 @@ const WizardSavedObjectsList = ({ submissionType, submissions }: { submissionTyp
   const classes = useStyles()
   const dispatch = useDispatch()
   const objectType = useSelector(state => state.objectType)
-  const handleObjectDelete = objectId => {
-    dispatch(deleteObjectFromFolder(objectId, objectType))
-  }
+  const [connError, setConnError] = useState(false)
+  const [responseError, setResponseError] = useState({})
+  const [errorPrefix, setErrorPrefix] = useState("")
   const newObject = submissions.filter(x => !ref.current?.includes(x))
+
+  const handleObjectDelete = objectId => {
+    dispatch(deleteObjectFromFolder(objectId, objectType)).catch(error => {
+      setConnError(true)
+      setResponseError(JSON.parse(error))
+      setErrorPrefix("Can't delete object")
+    })
+  }
+
   return (
     <div className={classes.objectList}>
       <h3 className={classes.header}>Submitted {submissionType} items</h3>
@@ -96,6 +107,9 @@ const WizardSavedObjectsList = ({ submissionType, submissions }: { submissionTyp
           )
         })}
       </List>
+      {connError && (
+        <WizardStatusMessageHandler successStatus="error" response={responseError} prefixText={errorPrefix} />
+      )}
     </div>
   )
 }

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -136,13 +136,18 @@ const WizardFillObjectDetailsForm = () => {
     setResponseInfo(response)
 
     if (response.ok) {
-      setSuccessStatus("success")
       dispatch(
         addObjectToFolder(folderId, {
           accessionId: response.data.accessionId,
           schema: objectType,
         })
       )
+        .then(() => setSuccessStatus("success"))
+        .catch(error => {
+          setSuccessStatus("error")
+          setResponseInfo(error)
+          setErrorPrefix("Cannot connect to folder API")
+        })
     } else {
       setSuccessStatus("error")
       setErrorPrefix("Validation failed")

--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -81,7 +81,6 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
           defaultValue={folder ? folder.description : ""}
         ></MuiTextField>
       </form>
-      {/* {connError && <p>error</p>} */}
       {connError && <WizardStatusMessageHandler successStatus="error" response={responseError} prefixText="" />}
     </>
   )

--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -1,5 +1,5 @@
 //@flow
-import React from "react"
+import React, { useState } from "react"
 import type { ElementRef } from "react"
 
 import { makeStyles } from "@material-ui/core/styles"
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from "react-redux"
 
 import WizardHeader from "../WizardComponents/WizardHeader"
 import WizardStepper from "../WizardComponents/WizardStepper"
+import WizardStatusMessageHandler from "../WizardForms/WizardStatusMessageHandler"
 
 import { increment } from "features/wizardStepSlice"
 import { createNewDraftFolder, updateNewDraftFolder } from "features/wizardSubmissionFolderSlice"
@@ -31,46 +32,58 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
   const classes = useStyles()
   const dispatch = useDispatch()
   const folder = useSelector(state => state.submissionFolder)
-
+  const [connError, setConnError] = useState(false)
+  const [responseError, setResponseError] = useState({})
   const { register, errors, handleSubmit, formState } = useForm()
   const { isSubmitting } = formState
 
   const onSubmit = data => {
+    setConnError(false)
     if (folder) {
-      dispatch(updateNewDraftFolder(Object.assign({ ...data, folder })))
+      dispatch(updateNewDraftFolder(Object.assign({ ...data, folder }))).then(dispatch(increment()))
     } else {
       dispatch(createNewDraftFolder(data))
+        .then(() => {
+          dispatch(increment())
+        })
+        .catch(error => {
+          setConnError(true)
+          setResponseError(JSON.parse(error))
+        })
     }
-    dispatch(increment())
   }
 
   return (
-    <form className={classes.root} onSubmit={handleSubmit(onSubmit)} ref={createFolderFormRef}>
-      <MuiTextField
-        name="name"
-        label="Folder Name *"
-        variant="outlined"
-        fullWidth
-        inputRef={register({ required: true, validate: { name: value => value.length > 0 } })}
-        helperText={errors.name ? "Please give a name for folder." : null}
-        error={errors.name}
-        disabled={isSubmitting}
-        defaultValue={folder ? folder.name : ""}
-      ></MuiTextField>
-      <MuiTextField
-        name="description"
-        label="Folder Description *"
-        variant="outlined"
-        fullWidth
-        multiline
-        rows={5}
-        inputRef={register({ required: true, validate: { description: value => value.length > 0 } })}
-        helperText={errors.description ? "Please give a description for folder." : null}
-        error={errors.description}
-        disabled={isSubmitting}
-        defaultValue={folder ? folder.description : ""}
-      ></MuiTextField>
-    </form>
+    <>
+      <form className={classes.root} onSubmit={handleSubmit(onSubmit)} ref={createFolderFormRef}>
+        <MuiTextField
+          name="name"
+          label="Folder Name *"
+          variant="outlined"
+          fullWidth
+          inputRef={register({ required: true, validate: { name: value => value.length > 0 } })}
+          helperText={errors.name ? "Please give a name for folder." : null}
+          error={errors.name}
+          disabled={isSubmitting}
+          defaultValue={folder ? folder.name : ""}
+        ></MuiTextField>
+        <MuiTextField
+          name="description"
+          label="Folder Description *"
+          variant="outlined"
+          fullWidth
+          multiline
+          rows={5}
+          inputRef={register({ required: true, validate: { description: value => value.length > 0 } })}
+          helperText={errors.description ? "Please give a description for folder." : null}
+          error={errors.description}
+          disabled={isSubmitting}
+          defaultValue={folder ? folder.description : ""}
+        ></MuiTextField>
+      </form>
+      {/* {connError && <p>error</p>} */}
+      {connError && <WizardStatusMessageHandler successStatus="error" response={responseError} prefixText="" />}
+    </>
   )
 }
 

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -74,7 +74,6 @@ export const updateNewDraftFolder = (folderDetails: FolderFromForm) => async (di
     { ...folderDetails.folder },
     { name: folderDetails.name, description: folderDetails.description }
   )
-  console.log(updatedFolder)
   dispatch(setFolder(updatedFolder))
 }
 

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -55,12 +55,18 @@ export const createNewDraftFolder = (folderDetails: FolderFromForm) => async (di
     metadataObjects: [],
   }
   const response = await folderAPIService.createNewFolder(folderForBackend)
-  if (!response.ok) return
-  const folder: Folder = {
-    ...folderForBackend,
-    id: response.data.folderId,
-  }
-  dispatch(setFolder(folder))
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      const folder: Folder = {
+        ...folderForBackend,
+        id: response.data.folderId,
+      }
+      dispatch(setFolder(folder))
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
 }
 
 export const updateNewDraftFolder = (folderDetails: FolderFromForm) => async (dispatch: any => void) => {
@@ -68,48 +74,67 @@ export const updateNewDraftFolder = (folderDetails: FolderFromForm) => async (di
     { ...folderDetails.folder },
     { name: folderDetails.name, description: folderDetails.description }
   )
+  console.log(updatedFolder)
   dispatch(setFolder(updatedFolder))
 }
 
 export const addObjectToFolder = (folderID: string, objectDetails: ObjectInFolder) => async (dispatch: any => void) => {
   const changes = [{ op: "add", path: "/metadataObjects/-", value: objectDetails }]
   const response = await folderAPIService.patchFolderById(folderID, changes)
-  if (!response.ok) {
-    return
-  }
-  dispatch(addObject(objectDetails))
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      dispatch(addObject(objectDetails))
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
 }
 
 export const deleteObjectFromFolder = (objectId: string, objectType: string) => async (dispatch: any => void) => {
   const response = await objectAPIService.deleteObjectByAccessionId(objectType, objectId)
-  if (!response.ok) {
-    return
-  }
-  dispatch(deleteObject(objectId))
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      dispatch(deleteObject(objectId))
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
 }
 
-export const publishFolderContent = (folder: Folder) => async (dispatch: any => void) => {
+export const publishFolderContent = (folder: Folder) => async () => {
   const changes = [{ op: "replace", path: "/published", value: true }]
   const response = await folderAPIService.patchFolderById(folder.id, changes)
-  if (!response.ok) console.error(`Couldn't publish folder with id ${folder.id}`)
-  if (!response.ok) {
-    return
-  }
-  dispatch(resetFolder())
+
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
 }
 
-export const deleteFolderAndContent = (folder: Folder) => async (dispatch: any => void) => {
+export const deleteFolderAndContent = (folder: Folder) => async () => {
+  let message = ""
   if (folder) {
     const response = await folderAPIService.deleteFolderById(folder.id)
-    if (!response.ok) console.error(`Couldn't delete folder with id ${folder.id}`)
+    if (!response.ok) message = `Couldn't delete folder with id ${folder.id}`
     if (folder.metadataObjects) {
       await Promise.all(
         folder.metadataObjects.map(async object => {
           const response = await objectAPIService.deleteObjectByAccessionId(object.schema, object.accessionId)
-          if (!response.ok) console.error(`Couldn't delete object with accessionId ${object.accessionId}`)
+          if (!response.ok) message = `Couldn't delete object with accessionId ${object.accessionId}`
         })
       )
     }
+    return new Promise((resolve, reject) => {
+      if (response.ok) {
+        resolve(response)
+      } else {
+        reject({ response: JSON.stringify(response), message: message })
+      }
+    })
   }
-  dispatch(resetFolder())
 }


### PR DESCRIPTION
### Description

Check folder API response and set error if bad response. This is done in wizardSubmissionFolderSlice methods where API calls are made.

### Related issues

Fixes #65 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Check against API call responses in promise
- Catch and pass errors to components
- Show error messages via status message handler in snackbar

### Testing

- [x] Needs testing
