### PR TITLE
Bugfix/keyboard based xml upload

### DIFF
--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -88,7 +88,10 @@ const WizardUploadObjectXMLForm = () => {
   }
 
   const handleButton = () => {
-    document.getElementById("file-select-button")?.click()
+    //document.getElementById("file-select-button") ? document.getElementById("file-select-button").click() : null
+    // document.getElementById("file-select-button").click() //tested with change name of id and changing places of id and this function, no success.
+    // document.getElementsByName("fileUpload")[0].click() //ok
+    //console.log(document.getElementById("file-select-button")) //ok <input type="file" name="fileUpload" id="file-select-button" hidden="">
   }
 
   return (

--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -87,14 +87,21 @@ const WizardUploadObjectXMLForm = () => {
     dispatch(resetDraftStatus())
   }
 
+  const handleButton = () => {
+    document.getElementById("file-select-button")?.click()
+  }
+
   return (
     <div>
       {/* React Hook Form */}
       <form>
         <FormControl className={classes.root}>
           <div className={classes.fileField}>
-            <TextField placeholder={watchFile ? watchFile[0]?.name : "Name"} inputProps={{ readOnly: true }} />
-            <Button htmlFor="file-select-button" variant="contained" color="primary" component="label">
+            <TextField
+              placeholder={watchFile ? watchFile[0]?.name : "Name"}
+              inputProps={{ readOnly: true, tabIndex: -1 }}
+            />
+            <Button variant="contained" color="primary" component="label" onClick={() => handleButton()}>
               Choose file
             </Button>
             <input

--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -88,16 +88,11 @@ const WizardUploadObjectXMLForm = () => {
   }
 
   const handleButton = () => {
-    // there is a problem with flow and it complains about null values
-    // solution from: https://stackoverflow.com/questions/44979394/why-flow-still-complains-about-null-values-for-document-getelementbyid
     const fileSelect = document && document.getElementById("file-select-button")
 
     if (fileSelect && fileSelect.click()) {
       fileSelect.click()
     }
-    // document.getElementById("file-select-button").click() //tested with change name of id and changing places of id and this function, no success.
-    // document.getElementsByName("fileUpload")[0].click() //ok
-    //console.log(document.getElementById("file-select-button")) //ok <input type="file" name="fileUpload" id="file-select-button" hidden="">
   }
 
   return (


### PR DESCRIPTION
### Description

To enable click from keyboard it needs to be triggered from the button. This is an addition to it handles mouse click.

### Related issues

<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes https://github.com/CSCfi/metadata-submitter-frontend/issues/20

### Type of change
There is added a onClick event and the associated handleButton function.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

A new handleButton function is added, the function is triggered from the new onClick event in the "Choose file" button.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)


