### PR TITLE
Add apisauce monitor to check api requests and catch errors

### DIFF
--- a/src/services/errorMonitor.js
+++ b/src/services/errorMonitor.js
@@ -1,0 +1,18 @@
+// function to catch errors
+export const errorMonitor = res => {
+  if (!res.ok) {
+    switch (res.status) {
+      case 401:
+        window.location = "/error401"
+        break
+      case 403:
+        window.location = "/error403"
+        break
+      case 500:
+        window.location = "/error500"
+        break
+      default:
+        break
+    }
+  }
+}

--- a/src/services/folderAPI.js
+++ b/src/services/folderAPI.js
@@ -1,7 +1,11 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "/folders" })
+
+api.addMonitor(errorMonitor)
 
 const createNewFolder = async (folder: any) => {
   return await api.post(null, folder)

--- a/src/services/objectAPI.js
+++ b/src/services/objectAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "/objects" })
+api.addMonitor(errorMonitor)
 
 const createFromXML = async (objectType: string, XMLFile: string) => {
   let formData = new FormData()

--- a/src/services/publishAPI.js
+++ b/src/services/publishAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "/publish" })
+api.addMonitor(errorMonitor)
 
 const publishFolderById = async (folderId: string) => {
   return await api.patch(`/${folderId}`)

--- a/src/services/schemaAPI.js
+++ b/src/services/schemaAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "/schemas" })
+api.addMonitor(errorMonitor)
 
 const getSchemaByObjectType = async (objectType: string) => {
   return await api.get(`/${objectType}`)

--- a/src/services/submissionAPI.js
+++ b/src/services/submissionAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "" })
+api.addMonitor(errorMonitor)
 
 const validateXMLFile = async (objectType: string, XMLFile: any) => {
   let formData = new FormData()


### PR DESCRIPTION
### Description

Catch errors 401, 403, 500 from back-end and direct them to error handling pages 401, 403, 500

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/117

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- New file `errorMonitor.js` created to handle the redirection when errors 401, 403, 500 occur
- `apisauce monitors` are added to `/services` api calls

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Needs testing (start an issue or do a follow up PR about it)

### Mentions

- I tried to come up with a suitable unit test for the `monitors` but haven't figured out any good ways so far. Not sure if we need unit test for this.
- Some errors cannot be caught from client-side, may need to do the redirection from server-side (to be implemented later)
