### PR TITLE
Feature/notify draft object

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -17,12 +17,12 @@ describe("Basic e2e", function () {
     cy.get("textarea[name='description']").type("Test description")
     cy.get("button[type=button]").contains("Next").click()
 
-    // Fill a study form and save object
+    // Fill a study form and submit object
     cy.get("div[role=button]").contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()
     cy.get("input[name='descriptor.studyTitle']").type("Test title")
     cy.get("select[name='descriptor.studyType']").select("Metagenomics")
-    cy.get("button[type=submit]").contains("Save").click()
+    cy.get("button[type=submit]").contains("Submit").click()
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
     // Upload an xml file.

--- a/src/__tests__/WizardAddObjectStep.test.js
+++ b/src/__tests__/WizardAddObjectStep.test.js
@@ -23,6 +23,7 @@ describe("WizardAddObjectStep", () => {
         published: false,
         metadataObjects: [],
         id: "FOL12341234",
+        drafts: [{ accessionId: "TESTID1234", schema: "study" }],
       },
     })
     render(
@@ -45,6 +46,7 @@ describe("WizardAddObjectStep", () => {
             id: "FOL12341234",
             name: "Testname",
             published: false,
+            drafts: [{ accessionId: "TESTID1234", schema: "study" }],
           },
         })
         render(

--- a/src/__tests__/WizardObjectIndex.test.js
+++ b/src/__tests__/WizardObjectIndex.test.js
@@ -1,0 +1,38 @@
+import React from "react"
+
+import "@testing-library/jest-dom/extend-expect"
+import { render, screen } from "@testing-library/react"
+import { Provider } from "react-redux"
+import configureStore from "redux-mock-store"
+
+import WizardObjectIndex from "../components/NewDraftWizard/WizardComponents/WizardObjectIndex"
+
+const mockStore = configureStore([])
+
+describe("WizardObjectIndex", () => {
+  it("should render badge with number correctly", () => {
+    const store = mockStore({
+      submissionFolder: {
+        drafts: [
+          { accessionId: "TESTID1234", schema: "study" },
+          { accessionId: "TESTID5678", schema: "study" },
+          { accessionId: "TESTID0101", schema: "analysis" },
+          { accessionId: "TESTID0202", schema: "experiment" },
+        ],
+      },
+    })
+    render(
+      <Provider store={store}>
+        <WizardObjectIndex />
+      </Provider>
+    )
+    const badge = screen.queryAllByTestId("badge")
+    expect(badge).toHaveLength(8)
+    const studyBadge = screen.queryAllByTestId("badge")[0]
+    expect(studyBadge).toHaveTextContent(2)
+    const analysisBadge = screen.queryAllByTestId("badge")[4]
+    expect(analysisBadge).toHaveTextContent(1)
+    const experimentBadge = screen.queryAllByTestId("badge")[2]
+    expect(experimentBadge).toHaveTextContent(1)
+  })
+})

--- a/src/__tests__/WizardUploadObjectXMLForm.test.js
+++ b/src/__tests__/WizardUploadObjectXMLForm.test.js
@@ -21,6 +21,7 @@ describe("WizardStepper", () => {
       id: "FOL90524783",
       name: "Testname",
       published: false,
+      drafts: [{ accessionId: "TESTID1234", schema: "study" }],
     },
   })
 
@@ -30,7 +31,7 @@ describe("WizardStepper", () => {
         <WizardUploadObjectXMLForm />
       </Provider>
     )
-    const button = await screen.findByRole("button", { name: /save/i })
+    const button = await screen.findByRole("button", { name: /submit/i })
     expect(button).toHaveAttribute("disabled")
   })
 

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -42,8 +42,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.primary.main,
   },
   badge: {
-    marginLeft: "auto",
-    marginRight: theme.spacing(2),
+    margin: theme.spacing(2, 2, 2, "auto"),
     zIndex: 0,
   },
 }))
@@ -153,8 +152,17 @@ const WizardObjectIndex = () => {
   const currentSubmissionType = useSelector(state => state.submissionType)
   const draftStatus = useSelector(state => state.draftStatus)
 
+  const folder = useSelector(state => state.submissionFolder)
+  const draftObjects = folder.drafts
+    .map(draft => draft.schema)
+    .reduce((acc, val) => ((acc[val] = (acc[val] || 0) + 1), acc), {})
+
   const handlePanelChange = panel => (event, newExpanded) => {
     setExpandedObjectType(newExpanded ? panel : false)
+  }
+
+  const getBadgeContent = (objectType: string) => {
+    return draftObjects[objectType] ? draftObjects[objectType] : 0
   }
 
   const handleSubmissionTypeChange = (submissionType: string) => {
@@ -201,14 +209,7 @@ const WizardObjectIndex = () => {
               id="type-header"
             >
               <NoteAddIcon /> <Typography variant="subtitle1">{typeCapitalized}</Typography>
-              <Badge
-                anchorOrigin={{
-                  vertical: "middle",
-                  horizontal: "middle",
-                }}
-                badgeContent={1}
-                className={classes.badge}
-              />
+              <Badge badgeContent={getBadgeContent(objectType)} className={classes.badge} />
             </AccordionSummary>
             <AccordionDetails>
               <SubmissionTypeList

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -4,6 +4,7 @@ import React, { useState } from "react"
 import MuiAccordion from "@material-ui/core/Accordion"
 import MuiAccordionDetails from "@material-ui/core/AccordionDetails"
 import MuiAccordionSummary from "@material-ui/core/AccordionSummary"
+import MuiBadge from "@material-ui/core/Badge"
 import List from "@material-ui/core/List"
 import ListItem from "@material-ui/core/ListItem"
 import ListItemText from "@material-ui/core/ListItemText"
@@ -39,6 +40,11 @@ const useStyles = makeStyles(theme => ({
   },
   selectedAccordion: {
     backgroundColor: theme.palette.primary.main,
+  },
+  badge: {
+    marginLeft: "auto",
+    marginRight: theme.spacing(2),
+    zIndex: 0,
   },
 }))
 
@@ -86,6 +92,13 @@ const AccordionDetails = withStyles({
     padding: 0,
   },
 })(MuiAccordionDetails)
+
+const Badge = withStyles(theme => ({
+  badge: {
+    backgroundColor: theme.palette.common.white,
+    color: theme.palette.common.black,
+  },
+}))(MuiBadge)
 
 /*
  * Render list of submission types to be used in accordions
@@ -188,6 +201,14 @@ const WizardObjectIndex = () => {
               id="type-header"
             >
               <NoteAddIcon /> <Typography variant="subtitle1">{typeCapitalized}</Typography>
+              <Badge
+                anchorOrigin={{
+                  vertical: "middle",
+                  horizontal: "middle",
+                }}
+                badgeContent={1}
+                className={classes.badge}
+              />
             </AccordionSummary>
             <AccordionDetails>
               <SubmissionTypeList

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -96,6 +96,7 @@ const Badge = withStyles(theme => ({
   badge: {
     backgroundColor: theme.palette.common.white,
     color: theme.palette.common.black,
+    fontWeight: theme.typography.fontWeightBold,
   },
 }))(MuiBadge)
 
@@ -153,6 +154,8 @@ const WizardObjectIndex = () => {
   const draftStatus = useSelector(state => state.draftStatus)
 
   const folder = useSelector(state => state.submissionFolder)
+  // Get draft objects of current folder
+  // and count the amount of drafts of each existing objectType
   const draftObjects = folder.drafts
     .map(draft => draft.schema)
     .reduce((acc, val) => ((acc[val] = (acc[val] || 0) + 1), acc), {})

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -212,7 +212,7 @@ const WizardObjectIndex = () => {
               id="type-header"
             >
               <NoteAddIcon /> <Typography variant="subtitle1">{typeCapitalized}</Typography>
-              <Badge badgeContent={getBadgeContent(objectType)} className={classes.badge} />
+              <Badge badgeContent={getBadgeContent(objectType)} className={classes.badge} data-testid="badge" />
             </AccordionSummary>
             <AccordionDetails>
               <SubmissionTypeList

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -56,10 +56,19 @@ const useStyles = makeStyles(theme => ({
       },
     },
   },
-  formButton: {
-    marginLeft: theme.spacing(1),
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(2),
+  formButtonContainer: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  formButtonSave: {
+    margin: theme.spacing(2, "auto", 2, 1),
+    marginRight: "auto",
+  },
+  formButtonClear: {
+    margin: theme.spacing(2, 1, 2, "auto"),
+  },
+  formButtonSubmit: {
+    margin: theme.spacing(2, 1, 2, 1),
   },
 }))
 
@@ -162,7 +171,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
     if (alert) {
       clearInterval(increment.current)
     }
-    if (timer >= 5) {
+    if (timer >= 60) {
       saveDraft()
       clearInterval(increment.current)
     }
@@ -176,18 +185,27 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
         onChange={() => handleChange()}
       >
         <div>{JSONSchemaParser.buildFields(formSchema)}</div>
-        <div>
+        <div className={classes.formButtonContainer}>
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            className={classes.formButtonSave}
+            onClick={() => saveDraft()}
+          >
+            Save as Draft
+          </Button>
           <Button
             variant="contained"
             color="secondary"
             size="small"
-            className={classes.formButton}
+            className={classes.formButtonClear}
             onClick={() => resetForm()}
           >
             Clear form
           </Button>
-          <Button variant="contained" color="primary" size="small" type="submit" className={classes.formButton}>
-            Save
+          <Button variant="contained" color="primary" size="small" type="submit" className={classes.formButtonSubmit}>
+            Submit
           </Button>
         </div>
       </form>

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -205,7 +205,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
             Clear form
           </Button>
           <Button variant="contained" color="primary" size="small" type="submit" className={classes.formButtonSubmit}>
-            Submit
+            Submit {objectType}
           </Button>
         </div>
       </form>

--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -138,7 +138,7 @@ const WizardUploadObjectXMLForm = () => {
           disabled={isSubmitting || !watchFile || watchFile.length === 0 || errors.fileUpload != null}
           onClick={handleSubmit(onSubmit)}
         >
-          Save
+          Submit
         </Button>
       </form>
 


### PR DESCRIPTION
### Description
Each object would have a notification next to its title when there is any drafts been saved

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/107

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- Add a notification badge next to object title to count the saved drafts in each object
- Change button `Save` to `Submit object`
- Auto-saving time for draft changes from 5s to 60s
- New button `Save as Draft` is added so the user can manually save a form as a draft object
- Unit test for showing the correct number of saved drafts in each object

### Testing

- [x] Unit Tests
- [x] Needs testing (start an issue or do a follow up PR about it)

