### PR TITLE
Add test for Analysis object Fill form and check Summary amount of ob…

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -45,7 +45,10 @@ describe("Basic e2e", function () {
 
     // Fill an Analysis form and submit object
     cy.get("div[role=button]").contains("Analysis").click()
-    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("div[role=button]")
+      .contains("Fill Form")
+      .should("be.visible")
+      .then($btn => $btn.click())
 
     cy.get("form").within(() => {
       // Experiment

--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -6,7 +6,7 @@ describe("Basic e2e", function () {
     cy.get('[alt="CSC Login"]').click()
   })
 
-  it("should create new folder, add study form and publish folder", () => {
+  it("should create new folder, add Study form, upload Study XML file, add Analysis form and publish folder", () => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
     cy.visit(baseUrl + "newdraft")
@@ -44,12 +44,8 @@ describe("Basic e2e", function () {
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
 
     // Fill an Analysis form and submit object
-    cy.get("div[role=button]")
-      .contains("Analysis")
-      .then($analysis => {
-        $analysis.click()
-        cy.get("div").contains("Fill Form").click()
-      })
+    cy.get("div[role=button]").contains("Analysis").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
 
     cy.get("form").within(() => {
       // Experiment

--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -19,7 +19,7 @@ describe("Basic e2e", function () {
     cy.get("textarea[name='description']").type("Test description")
     cy.get("button[type=button]").contains("Next").click()
 
-    // Fill a study form and submit object
+    // Fill a Study form and submit object
     cy.get("div[role=button]").contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()
     cy.get("input[name='descriptor.studyTitle']").type("Test title")
@@ -27,7 +27,7 @@ describe("Basic e2e", function () {
     cy.get("button[type=submit]").contains("Submit").click()
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
-    // Upload an xml file.
+    // Upload a Study xml file.
     cy.get("div[role=button]").contains("Upload XML File").click()
     cy.fixture("study_test.xml").then(fileContent => {
       cy.get('input[type="file"]').attachFile({
@@ -40,11 +40,91 @@ describe("Basic e2e", function () {
     // Hacky way to get past RHF watch -method problem that doesn't allow cypress to get updated value for file
     cy.get("form").submit()
 
-    // Saved objects list should have newly added item
+    // Saved objects list should have newly added item from Study object
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
 
-    // // Navigate to summary and publish
+    // Fill an Analysis form and submit object
+    cy.get("div[role=button]")
+      .contains("Analysis")
+      .then($analysis => {
+        $analysis.click()
+        cy.get("div").contains("Fill Form").click()
+      })
+
+    cy.get("form").within(() => {
+      // Experiment
+      cy.get("input[name='experimentRef.accessionId']").type("Experiement Test Accession Id")
+      cy.get("input[name='experimentRef.identifiers.submitterId.namespace']").type("Experiement Test Namespace")
+      cy.get("input[name='experimentRef.identifiers.submitterId.value']").type("Experiement Test Value")
+
+      // Study
+      cy.get("input[name='studyRef.accessionId']").type("Study Test Accession Id")
+      cy.get("input[name='studyRef.identifiers.submitterId.namespace']").type("Study Test Namespace")
+      cy.get("input[name='studyRef.identifiers.submitterId.value']").type("Study Test Value")
+
+      // Sample
+      cy.get("input[name='sampleRef.accessionId']").type("Sample Test Accession Id")
+      cy.get("input[name='sampleRef.identifiers.submitterId.namespace']").type("Sample Test Namespace")
+      cy.get("input[name='sampleRef.identifiers.submitterId.value']").type("Sample Test Value")
+
+      // Run
+      cy.get("input[name='runRef.accessionId']").type("Run Test Accession Id")
+      cy.get("input[name='runRef.identifiers.submitterId.namespace']").type("Run Test Namespace")
+      cy.get("input[name='runRef.identifiers.submitterId.value']").type("Run Test Value")
+
+      // Analysis
+      cy.get("input[name='analysisRef.accessionId']").type("Analysis Test Accession Id")
+      cy.get("input[name='analysisRef.identifiers.submitterId.namespace']").type("Analysis Test Namespace")
+      cy.get("input[name='analysisRef.identifiers.submitterId.value']").type("Analysis Test Value")
+
+      cy.get("h3")
+        .contains("Reference Alignment")
+        .parent("div.formSection")
+        .within(() => {
+          cy.get("button").contains("Add new item").click()
+          cy.get("input[name='analysisType.referenceAlignment.sequence[0].accessionId']").type("Reference Accession Id")
+        })
+
+      cy.get("h3")
+        .contains("Sequence Variation")
+        .parent("div.formSection")
+        .within(() => {
+          cy.get("input[name='analysisType.sequenceVariation.assembly.standard.accessionId']").type(
+            "Sequence Standard Accession Id"
+          )
+          cy.get("button").contains("Add new item").click()
+          cy.get("input[name='analysisType.sequenceVariation.sequence[0].accessionId']").type(
+            "Squence Sequence Accession Id"
+          )
+        })
+
+      cy.get("h3")
+        .contains("Processed Reads")
+        .parent("div.formSection")
+        .within(() => {
+          cy.get("input[name='analysisType.processedReads.assembly.standard.accessionId']").type(
+            "Processed Standard Accession Id"
+          )
+          cy.get("button").contains("Add new item").click()
+
+          cy.get("input[name='analysisType.processedReads.sequence[0].accessionId']").type(
+            "Processed Sequence Accession Id"
+          )
+        })
+      cy.root().submit()
+    })
+
+    // Saved objects list should have newly added item from Analysis object
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Navigate to summary
     cy.get("button[type=button]").contains("Next").click()
+
+    // Check the amount of submitted objects in each object type
+    cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 2)
+    cy.get("h6").contains("Analysis").parent("div").children().eq(1).should("have.text", 1)
+
+    // Navigate to publish
     cy.get("button[type=button]").contains("Publish").click()
     cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
   })

--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -52,9 +52,9 @@ describe("Basic e2e", function () {
 
     cy.get("form").within(() => {
       // Experiment
-      cy.get("input[name='experimentRef.accessionId']").type("Experiement Test Accession Id")
-      cy.get("input[name='experimentRef.identifiers.submitterId.namespace']").type("Experiement Test Namespace")
-      cy.get("input[name='experimentRef.identifiers.submitterId.value']").type("Experiement Test Value")
+      cy.get("input[name='experimentRef.accessionId']").type("Experiment Test Accession Id")
+      cy.get("input[name='experimentRef.identifiers.submitterId.namespace']").type("Experiment Test Namespace")
+      cy.get("input[name='experimentRef.identifiers.submitterId.value']").type("Experiment Test Value")
 
       // Study
       cy.get("input[name='studyRef.accessionId']").type("Study Test Accession Id")


### PR DESCRIPTION
### Description

Add test for filling form in Analysis object and check the Summary of objects if it has the correct amount

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/31


### Changes Made

- Extend `Wizard Layout` test in `app.spec.js`: Filling form in Analysis object and submit it
- Test that Summary has the correct number of Study objects and Analysis object

### Testing

- [x] e2e test




