### PR TITLE
remove warnings caused by wrong error type in folder creation

### DIFF
--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -63,7 +63,7 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
           fullWidth
           inputRef={register({ required: true, validate: { name: value => value.length > 0 } })}
           helperText={errors.name ? "Please give a name for folder." : null}
-          error={errors.name}
+          error={errors.name ? true : false}
           disabled={isSubmitting}
           defaultValue={folder ? folder.name : ""}
         ></MuiTextField>
@@ -76,7 +76,7 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
           rows={5}
           inputRef={register({ required: true, validate: { description: value => value.length > 0 } })}
           helperText={errors.description ? "Please give a description for folder." : null}
-          error={errors.description}
+          error={errors.description ? true : false}
           disabled={isSubmitting}
           defaultValue={folder ? folder.description : ""}
         ></MuiTextField>


### PR DESCRIPTION
### Description

Small change to set boolean instead of object to MuiTextField to remove warnings.

### Related issues

Fixes #131


### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

Set the MuiTextField error to error={errors.name ? true : false} , to remove warnings.

### Testing

No testing needed, only review.


