### PR TITLE
Feature/drafts and folders in homepage

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -1,4 +1,4 @@
-describe("home test", function () {
+describe("Home e2e", function () {
   const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
 
   beforeEach(() => {
@@ -56,11 +56,15 @@ describe("home test", function () {
 
     // Check the created folder existing in the list and navigate to see its details
     cy.get("ul.MuiList-root")
-      .children()
-      .last()
-      .contains("Test unpublished folder", { timeout: 10000 })
       .should("be.visible")
-      .then($el => $el.click())
+      .then($el =>
+        $el
+          .children()
+          .last()
+          .contains("Test unpublished folder", { timeout: 10000 })
+          .should("be.visible")
+          .then($el => $el.click())
+      )
 
     // Check the selected folder has the correct amount of objects
     cy.get("table", { timeout: 10000 }).should("be.visible")
@@ -133,11 +137,15 @@ describe("home test", function () {
 
     // Check the created folder existing in the list and navigate to see its details
     cy.get("ul.MuiList-root")
-      .children()
-      .last()
-      .contains("Test published folder")
       .should("be.visible")
-      .then($el => $el.click())
+      .then($el =>
+        $el
+          .children()
+          .last()
+          .contains("Test published folder")
+          .should("be.visible")
+          .then($el => $el.click())
+      )
 
     // Check the selected folder has the correct amount of objects
     cy.get("table", { timeout: 10000 }).should("be.visible")

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -1,0 +1,163 @@
+describe("home test", function () {
+  const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
+
+  beforeEach(() => {
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+  })
+
+  it("show Overview submissions in Home page, create a draft folder, navigate to see folder details, delete object inside folder, navigate back to Overview submissions", () => {
+    // Overview submissions should have 2 different list and max. 5 items each list
+    cy.contains("Your Draft Submissions", { timeout: 10000 }).should("be.visible")
+    cy.contains("Your Published Submissions").should("be.visible")
+
+    cy.get("ul.MuiList-root").eq(0).children().should("have.length.at.most", 5)
+    cy.get("ul.MuiList-root").eq(1).children().should("have.length.at.most", 5)
+
+    // Create a new Unpublished folder
+    cy.get("button").contains("Create Submission").click()
+
+    // Navigate to folder creation
+    cy.get("button[type=button]").contains("New folder").click()
+
+    // Add folder name & description, navigate to editing folder
+    cy.get("input[name='name']").type("Test unpublished folder")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Fill a Study form
+    cy.get("div[role=button]", { timeout: 10000 }).contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Test title")
+    cy.get("select[name='descriptor.studyType']").select("Resequencing")
+
+    // Submit form
+    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Navigate to summary
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Check the amount of submitted objects in Study
+    cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
+
+    // Navigate to publish
+    cy.get("button[type=button]").contains("Save and Exit").click()
+    cy.get('button[aria-label="Save a new folder and move to frontpage"]').contains("Return to homepage").click()
+
+    // Click "See all" button to navigate to all unpublished folders list
+    cy.get("div.MuiCardActions-root", { timeout: 30000 })
+      .first()
+      .should("be.visible")
+      .find("button")
+      .contains("See all")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    // Check the created folder existing in the list and navigate to see its details
+    cy.get("ul.MuiList-root")
+      .children()
+      .last()
+      .contains("Test unpublished folder", { timeout: 10000 })
+      .should("be.visible")
+      .then($el => $el.click())
+
+    // Check the selected folder has the correct amount of objects
+    cy.get("table", { timeout: 10000 }).should("be.visible")
+
+    cy.get("tbody").should("be.visible")
+    cy.get("tbody>tr").should("have.length", 1)
+
+    // Delete an object inside the folder
+    cy.get("button[aria-label='Delete this object']")
+      .should("be.visible")
+      .then($btn => $btn.click())
+    cy.get("tbody>tr", { timeout: 10000 }).should("have.length", 0)
+
+    // Navigate back to unpublished folders list
+    cy.contains("Your draft submissions")
+      .should("be.visible")
+      .then($el => $el.click())
+
+    // Close unpublished folders list
+    cy.get("div.MuiCardActions-root")
+      .contains("Close")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    // Check Overview submissions page is shown
+    cy.contains("Your Draft Submissions").should("be.visible")
+    cy.contains("Your Published Submissions").should("be.visible")
+  })
+
+  it("create a published folder, navigate to see folder details, delete object inside folder, navigate back to Overview submissions", () => {
+    // Create a new Published folder
+    cy.get("button").contains("Create Submission").click()
+
+    // Navigate to folder creation
+    cy.get("button[type=button]").contains("New folder").click()
+
+    // Add folder name & description, navigate to editing folder
+    cy.get("input[name='name']").type("Test published folder")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Fill a Study form
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Test title")
+    cy.get("select[name='descriptor.studyType']").select("Resequencing")
+
+    // Submit form
+    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Navigate to summary
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Check the amount of submitted objects in Study
+    cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
+
+    // Navigate to publish
+    cy.get("button[type=button]").contains("Publish").click()
+    cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
+
+    // Click "See all" button to navigate to all published folders list
+    cy.get("div.MuiCardActions-root", { timeout: 30000 })
+      .last()
+      .should("be.visible")
+      .find("button")
+      .contains("See all")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    // Check the created folder existing in the list and navigate to see its details
+    cy.get("ul.MuiList-root")
+      .children()
+      .last()
+      .contains("Test published folder")
+      .should("be.visible")
+      .then($el => $el.click())
+
+    // Check the selected folder has the correct amount of objects
+    cy.get("table", { timeout: 10000 }).should("be.visible")
+
+    cy.get("tbody").should("be.visible")
+    cy.get("tbody>tr").should("have.length", 1)
+
+    // Navigate back to published folders list
+    cy.contains("Your published submissions")
+      .should("be.visible")
+      .then($el => $el.click())
+
+    // Close published folders list
+    cy.get("div.MuiCardActions-root")
+      .contains("Close")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    // Check Overview submissions page is shown
+    cy.contains("Your Draft Submissions").should("be.visible")
+    cy.contains("Your Published Submissions").should("be.visible")
+  })
+})

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -41,10 +41,11 @@ describe("Home e2e", function () {
     // Check the amount of submitted objects in Study
     cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
 
-    // Navigate to publish
+    // Save folder and navigate to Home page
     cy.get("button[type=button]").contains("Save and Exit").click()
     cy.get('button[aria-label="Save a new folder and move to frontpage"]').contains("Return to homepage").click()
 
+    cy.reload()
     // Click "See all" button to navigate to all unpublished folders list
     cy.get("div.MuiCardActions-root", { timeout: 30000 })
       .first()
@@ -55,15 +56,14 @@ describe("Home e2e", function () {
       .then($btn => $btn.click())
 
     // Check the created folder existing in the list and navigate to see its details
-    cy.get("ul.MuiList-root")
+    cy.get("ul.MuiList-root", { timeout: 10000 })
       .should("be.visible")
-      .then($el =>
-        $el
-          .children()
-          .last()
-          .contains("Test unpublished folder", { timeout: 10000 })
+      .within(() =>
+        cy
+          .get("div.MuiButtonBase-root")
+          .filter(':contains("Test unpublished folder")', { timeout: 30000 })
           .should("be.visible")
-          .then($el => $el.click())
+          .then($el => $el.last().click())
       )
 
     // Check the selected folder has the correct amount of objects
@@ -126,6 +126,7 @@ describe("Home e2e", function () {
     cy.get("button[type=button]").contains("Publish").click()
     cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
 
+    cy.reload()
     // Click "See all" button to navigate to all published folders list
     cy.get("div.MuiCardActions-root", { timeout: 30000 })
       .last()
@@ -136,15 +137,14 @@ describe("Home e2e", function () {
       .then($btn => $btn.click())
 
     // Check the created folder existing in the list and navigate to see its details
-    cy.get("ul.MuiList-root")
+    cy.get("ul.MuiList-root", { timeout: 10000 })
       .should("be.visible")
-      .then($el =>
-        $el
-          .children()
-          .last()
-          .contains("Test published folder")
+      .within(() =>
+        cy
+          .get("div.MuiButtonBase-root")
+          .filter(':contains("Test published folder")', { timeout: 30000 })
           .should("be.visible")
-          .then($el => $el.click())
+          .then($el => $el.last().click())
       )
 
     // Check the selected folder has the correct amount of objects

--- a/src/__tests__/Home.test.js
+++ b/src/__tests__/Home.test.js
@@ -15,6 +15,14 @@ const mockStore = configureStore(middlewares)
 describe("HomePage", () => {
   const store = mockStore({
     user: { name: "Test User" },
+    selectedFolder: {
+      folderId: "Test folderId",
+      name: "Test name",
+      description: "Test description",
+      drafts: [],
+      metadataObjects: [],
+      allObjects: [],
+    },
   })
   beforeEach(() => {
     render(

--- a/src/__tests__/Page403.test.js
+++ b/src/__tests__/Page403.test.js
@@ -60,8 +60,6 @@ describe("Page403", () => {
       jest.advanceTimersByTime(10000)
     })
 
-    component.getByText("Your draft submissions")
-    expect(component.getByText("Your draft submissions")).toBeInTheDocument()
     jest.useRealTimers()
   })
 })

--- a/src/__tests__/Page403.test.js
+++ b/src/__tests__/Page403.test.js
@@ -35,6 +35,14 @@ describe("Page403", () => {
     jest.useFakeTimers()
     const store = mockStore({
       user: { name: "test" },
+      selectedFolder: {
+        folderId: "Test folderId",
+        name: "Test name",
+        description: "Test description",
+        drafts: [],
+        metadataObjects: [],
+        allObjects: [],
+      },
     })
     let component = render(
       <Provider store={store}>
@@ -52,8 +60,8 @@ describe("Page403", () => {
       jest.advanceTimersByTime(10000)
     })
 
-    component.getByText("Your Draft Submissions")
-    expect(component.getByText("Your Draft Submissions")).toBeInTheDocument()
+    component.getByText("Your draft submissions")
+    expect(component.getByText("Your draft submissions")).toBeInTheDocument()
     jest.useRealTimers()
   })
 })

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -1,0 +1,54 @@
+//@flow
+import React from "react"
+
+// import { makeStyles } from "@material-ui/core/styles"
+import Table from "@material-ui/core/Table"
+import TableBody from "@material-ui/core/TableBody"
+import TableCell from "@material-ui/core/TableCell"
+import TableContainer from "@material-ui/core/TableContainer"
+import TableHead from "@material-ui/core/TableHead"
+import TableRow from "@material-ui/core/TableRow"
+
+// const useStyles = makeStyles(theme => ({}))
+
+type SubmissionDetailTableProps = {
+  headRows: Array<string>,
+  bodyRows: Array<string>,
+}
+
+const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
+  //   const classes = useStyles()
+
+  return (
+    <TableContainer>
+      <Table aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            {props.headRows.map((row, index) => (
+              <TableCell key={index}>{row}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {props.bodyRows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row}
+              </TableCell>
+              <TableCell>{row}</TableCell>
+              <TableCell>{row}</TableCell>
+              <TableCell>{row}</TableCell>
+              <TableCell>{row}</TableCell>
+              <TableCell>View</TableCell>
+              <TableCell>Edit</TableCell>
+              <TableCell>Delete</TableCell>
+              <TableCell>Show details</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+export default SubmissionDetailTable

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -1,6 +1,7 @@
 //@flow
 import React from "react"
 
+import Button from "@material-ui/core/Button"
 import Card from "@material-ui/core/Card"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
@@ -62,15 +63,25 @@ const useStyles = makeStyles(theme => ({
 
 const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
 
+type BodyRows = {
+  accessionId: string,
+  lastModified: string,
+  objectType: string,
+  status: string,
+  title: string,
+}
+
 type SubmissionDetailTableProps = {
   folderTitle: string,
-  bodyRows: Array<any>,
+  bodyRows: Array<BodyRows>,
   folderType: string,
   onClickCardHeader: () => void,
+  onDelete: (objectId: string, objectType: string, objectStatus: string) => void,
 }
 
 const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
   const classes = useStyles()
+  const { bodyRows, folderTitle, folderType, onClickCardHeader, onDelete } = props
 
   const getDateFormat = (date: string) => {
     const d = new Date(date)
@@ -85,9 +96,9 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
       <CardHeader
         className={classes.cardHeader}
         avatar={<KeyboardBackspaceIcon className={classes.backIcon} />}
-        title={`Your ${props.folderType} submissions`}
+        title={`Your ${folderType} submissions`}
         titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
-        onClick={props.onClickCardHeader}
+        onClick={onClickCardHeader}
       />
       <CardContent>
         <TableContainer component={Paper}>
@@ -97,13 +108,9 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                 <TableCell align="left" colSpan={8} padding="none">
                   <ListItem dense className={classes.tableHeader}>
                     <ListItemIcon className={classes.tableIcon}>
-                      {props.folderType === "published" ? (
-                        <FolderIcon color="primary" />
-                      ) : (
-                        <FolderOpenIcon color="primary" />
-                      )}
+                      {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                     </ListItemIcon>
-                    <ListItemText primary={props.folderTitle} />
+                    <ListItemText primary={folderTitle} />
                   </ListItem>
                 </TableCell>
               </TableRow>
@@ -116,7 +123,7 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {props.bodyRows?.map((row, index) => (
+              {bodyRows?.map((row, index) => (
                 <TableRow key={index}>
                   <TableCell component="th" scope="row">
                     {row.title}
@@ -124,10 +131,23 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                   <TableCell className={classes.objectType}>{row.objectType}</TableCell>
                   <TableCell>{row.status}</TableCell>
                   <TableCell>{getDateFormat(row.lastModified)}</TableCell>
-                  <TableCell>View</TableCell>
-                  <TableCell>Edit</TableCell>
-                  <TableCell>Delete</TableCell>
-                  <TableCell>Show details</TableCell>
+                  <TableCell>
+                    <Button>View</Button>
+                  </TableCell>
+                  <TableCell>
+                    <Button disabled={folderType === "published"}>Edit</Button>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      disabled={folderType === "published"}
+                      onClick={() => onDelete(row.accessionId, row.objectType, row.status)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                  <TableCell>
+                    <Button>Show details</Button>
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -16,6 +16,7 @@ import TableCell from "@material-ui/core/TableCell"
 import TableContainer from "@material-ui/core/TableContainer"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import Typography from "@material-ui/core/Typography"
 import FolderIcon from "@material-ui/icons/Folder"
 import FolderOpenIcon from "@material-ui/icons/FolderOpen"
 import KeyboardBackspaceIcon from "@material-ui/icons/KeyboardBackspace"
@@ -91,6 +92,82 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
     return `${day}.${month}.${year}`
   }
 
+  // Renders when current folder has the object(s)
+  const CurrentFolder = () => (
+    <CardContent>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell colSpan={8} padding="none">
+                <ListItem dense className={classes.tableHeader}>
+                  <ListItemIcon className={classes.tableIcon}>
+                    {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
+                  </ListItemIcon>
+                  <ListItemText primary={folderTitle} />
+                  <Button color="secondary" disabled aria-label="Edit current folder">
+                    Edit
+                  </Button>
+                  <Button variant="contained" disabled aria-label="Publish current folder">
+                    Publish
+                  </Button>
+                </ListItem>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              {headRows.map((row, index) => (
+                <TableCell key={index} className={classes.headRows}>
+                  {row}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {bodyRows?.map((row, index) => (
+              <TableRow key={index}>
+                <TableCell component="th" scope="row">
+                  {row.title}
+                </TableCell>
+                <TableCell className={classes.objectType}>{row.objectType}</TableCell>
+                <TableCell>{row.status}</TableCell>
+                <TableCell>{getDateFormat(row.lastModified)}</TableCell>
+                <TableCell>
+                  <Button>View</Button>
+                </TableCell>
+                <TableCell>
+                  <Button disabled={folderType === "published"} aria-label="Edit this object">
+                    Edit
+                  </Button>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    disabled={folderType === "published"}
+                    aria-label="Delete this object"
+                    onClick={() => onDelete(row.accessionId, row.objectType, row.status)}
+                  >
+                    Delete
+                  </Button>
+                </TableCell>
+                <TableCell>
+                  <Button>Show details</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </CardContent>
+  )
+
+  // Renders when current folder is empty
+  const EmptyFolder = () => (
+    <CardContent>
+      <Typography align="center" variant="body2">
+        Current folder is empty
+      </Typography>
+    </CardContent>
+  )
+
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader
@@ -100,69 +177,7 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
         titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
         onClick={onClickCardHeader}
       />
-      <CardContent>
-        <TableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell colSpan={8} padding="none">
-                  <ListItem dense className={classes.tableHeader}>
-                    <ListItemIcon className={classes.tableIcon}>
-                      {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
-                    </ListItemIcon>
-                    <ListItemText primary={folderTitle} />
-                    <Button color="secondary" disabled aria-label="Edit current folder">
-                      Edit
-                    </Button>
-                    <Button variant="contained" disabled aria-label="Publish current folder">
-                      Publish
-                    </Button>
-                  </ListItem>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                {headRows.map((row, index) => (
-                  <TableCell key={index} className={classes.headRows}>
-                    {row}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {bodyRows?.map((row, index) => (
-                <TableRow key={index}>
-                  <TableCell component="th" scope="row">
-                    {row.title}
-                  </TableCell>
-                  <TableCell className={classes.objectType}>{row.objectType}</TableCell>
-                  <TableCell>{row.status}</TableCell>
-                  <TableCell>{getDateFormat(row.lastModified)}</TableCell>
-                  <TableCell>
-                    <Button>View</Button>
-                  </TableCell>
-                  <TableCell>
-                    <Button disabled={folderType === "published"} aria-label="Edit this object">
-                      Edit
-                    </Button>
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      disabled={folderType === "published"}
-                      aria-label="Delete this object"
-                      onClick={() => onDelete(row.accessionId, row.objectType, row.status)}
-                    >
-                      Delete
-                    </Button>
-                  </TableCell>
-                  <TableCell>
-                    <Button>Show details</Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </CardContent>
+      {bodyRows?.length > 0 ? <CurrentFolder /> : <EmptyFolder />}
     </Card>
   )
 }

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -63,7 +63,7 @@ const useStyles = makeStyles(theme => ({
 
 const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
 
-type BodyRows = {
+type DetailObject = {
   accessionId: string,
   lastModified: string,
   objectType: string,
@@ -73,7 +73,7 @@ type BodyRows = {
 
 type SubmissionDetailTableProps = {
   folderTitle: string,
-  bodyRows: Array<BodyRows>,
+  bodyRows: Array<DetailObject>,
   folderType: string,
   onClickCardHeader: () => void,
   onDelete: (objectId: string, objectType: string, objectStatus: string) => void,

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -63,7 +63,7 @@ const useStyles = makeStyles(theme => ({
 
 const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
 
-type DetailObject = {
+type ObjectDetails = {
   accessionId: string,
   lastModified: string,
   objectType: string,
@@ -73,7 +73,7 @@ type DetailObject = {
 
 type SubmissionDetailTableProps = {
   folderTitle: string,
-  bodyRows: Array<DetailObject>,
+  bodyRows: Array<ObjectDetails>,
   folderType: string,
   onClickCardHeader: () => void,
   onDelete: (objectId: string, objectType: string, objectStatus: string) => void,

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -105,10 +105,10 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                     {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                   </ListItemIcon>
                   <ListItemText primary={folderTitle} />
-                  <Button color="secondary" disabled aria-label="Edit current folder">
+                  <Button color="secondary" disabled={folderType === "published"} aria-label="Edit current folder">
                     Edit
                   </Button>
-                  <Button variant="contained" disabled aria-label="Publish current folder">
+                  <Button disabled={folderType === "published"} aria-label="Publish current folder" variant="contained">
                     Publish
                   </Button>
                 </ListItem>

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -1,53 +1,87 @@
 //@flow
 import React from "react"
 
-// import { makeStyles } from "@material-ui/core/styles"
+import Card from "@material-ui/core/Card"
+import CardContent from "@material-ui/core/CardContent"
+import CardHeader from "@material-ui/core/CardHeader"
+import { makeStyles } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
 import TableCell from "@material-ui/core/TableCell"
 import TableContainer from "@material-ui/core/TableContainer"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import KeyboardBackspaceIcon from "@material-ui/icons/KeyboardBackspace"
 
-// const useStyles = makeStyles(theme => ({}))
+const useStyles = makeStyles(theme => ({
+  backIcon: {
+    "&:hover": {
+      cursor: "pointer",
+    },
+  },
+  card: {
+    border: "none",
+    padding: theme.spacing(0),
+  },
+  cardHeader: {
+    fontSize: "0.5em",
+    padding: 0,
+    marginTop: theme.spacing(1),
+    "&:hover": {
+      cursor: "pointer",
+    },
+  },
+}))
+
+const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
 
 type SubmissionDetailTableProps = {
-  headRows: Array<string>,
-  bodyRows: Array<string>,
+  bodyRows: Array<any>,
+  folderType: string,
+  onClickBackIcon: () => void,
 }
 
 const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
-  //   const classes = useStyles()
+  const classes = useStyles()
 
   return (
-    <TableContainer>
-      <Table aria-label="simple table">
-        <TableHead>
-          <TableRow>
-            {props.headRows.map((row, index) => (
-              <TableCell key={index}>{row}</TableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {props.bodyRows.map((row, index) => (
-            <TableRow key={index}>
-              <TableCell component="th" scope="row">
-                {row}
-              </TableCell>
-              <TableCell>{row}</TableCell>
-              <TableCell>{row}</TableCell>
-              <TableCell>{row}</TableCell>
-              <TableCell>{row}</TableCell>
-              <TableCell>View</TableCell>
-              <TableCell>Edit</TableCell>
-              <TableCell>Delete</TableCell>
-              <TableCell>Show details</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Card className={classes.card} variant="outlined">
+      <CardHeader
+        className={classes.cardHeader}
+        avatar={<KeyboardBackspaceIcon className={classes.backIcon} onClick={props.onClickBackIcon} />}
+        title={`Your ${props.folderType} folders`}
+        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
+      />
+      <CardContent>
+        <TableContainer>
+          <Table aria-label="simple table">
+            <TableHead>
+              <TableRow>
+                {headRows.map((row, index) => (
+                  <TableCell key={index}>{row}</TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {props.bodyRows.map((row, index) => (
+                <TableRow key={index}>
+                  <TableCell component="th" scope="row">
+                    {row.title}
+                  </TableCell>
+                  <TableCell>{row.objectType}</TableCell>
+                  <TableCell>{row.status}</TableCell>
+                  <TableCell>{row.lastModified}</TableCell>
+                  <TableCell>View</TableCell>
+                  <TableCell>Edit</TableCell>
+                  <TableCell>Delete</TableCell>
+                  <TableCell>Show details</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -53,6 +53,11 @@ const useStyles = makeStyles(theme => ({
   headRows: {
     fontWeight: "bold",
   },
+  objectType: {
+    "&:first-letter": {
+      textTransform: "capitalize",
+    },
+  },
 }))
 
 const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
@@ -116,7 +121,7 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                   <TableCell component="th" scope="row">
                     {row.title}
                   </TableCell>
-                  <TableCell>{row.objectType}</TableCell>
+                  <TableCell className={classes.objectType}>{row.objectType}</TableCell>
                   <TableCell>{row.status}</TableCell>
                   <TableCell>{getDateFormat(row.lastModified)}</TableCell>
                   <TableCell>View</TableCell>

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -67,6 +67,14 @@ type SubmissionDetailTableProps = {
 const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
   const classes = useStyles()
 
+  const getDateFormat = (date: string) => {
+    const d = new Date(date)
+    const day = d.getDate()
+    const month = d.getMonth() + 1
+    const year = d.getFullYear()
+    return `${day}.${month}.${year}`
+  }
+
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader
@@ -110,7 +118,7 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                   </TableCell>
                   <TableCell>{row.objectType}</TableCell>
                   <TableCell>{row.status}</TableCell>
-                  <TableCell>{row.lastModified}</TableCell>
+                  <TableCell>{getDateFormat(row.lastModified)}</TableCell>
                   <TableCell>View</TableCell>
                   <TableCell>Edit</TableCell>
                   <TableCell>Delete</TableCell>

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -111,10 +111,10 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                       {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                     </ListItemIcon>
                     <ListItemText primary={folderTitle} />
-                    <Button color="secondary" disabled>
+                    <Button color="secondary" disabled aria-label="Edit current folder">
                       Edit
                     </Button>
-                    <Button variant="contained" disabled>
+                    <Button variant="contained" disabled aria-label="Publish current folder">
                       Publish
                     </Button>
                   </ListItem>
@@ -141,11 +141,14 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
                     <Button>View</Button>
                   </TableCell>
                   <TableCell>
-                    <Button disabled={folderType === "published"}>Edit</Button>
+                    <Button disabled={folderType === "published"} aria-label="Edit this object">
+                      Edit
+                    </Button>
                   </TableCell>
                   <TableCell>
                     <Button
                       disabled={folderType === "published"}
+                      aria-label="Delete this object"
                       onClick={() => onDelete(row.accessionId, row.objectType, row.status)}
                     >
                       Delete

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -4,6 +4,10 @@ import React from "react"
 import Card from "@material-ui/core/Card"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
+import ListItem from "@material-ui/core/ListItem"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import ListItemText from "@material-ui/core/ListItemText"
+import Paper from "@material-ui/core/Paper"
 import { makeStyles } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableBody from "@material-ui/core/TableBody"
@@ -11,6 +15,8 @@ import TableCell from "@material-ui/core/TableCell"
 import TableContainer from "@material-ui/core/TableContainer"
 import TableHead from "@material-ui/core/TableHead"
 import TableRow from "@material-ui/core/TableRow"
+import FolderIcon from "@material-ui/icons/Folder"
+import FolderOpenIcon from "@material-ui/icons/FolderOpen"
 import KeyboardBackspaceIcon from "@material-ui/icons/KeyboardBackspace"
 
 const useStyles = makeStyles(theme => ({
@@ -31,14 +37,31 @@ const useStyles = makeStyles(theme => ({
       cursor: "pointer",
     },
   },
+  tableHeader: {
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+  },
+  tableIcon: {
+    minWidth: 35,
+    minHeight: 35,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: theme.palette.common.white,
+    marginRight: theme.spacing(1),
+  },
+  headRows: {
+    fontWeight: "bold",
+  },
 }))
 
 const headRows = ["Title", "Object type", "Status", "Last modified", "", "", "", ""]
 
 type SubmissionDetailTableProps = {
+  folderTitle: string,
   bodyRows: Array<any>,
   folderType: string,
-  onClickBackIcon: () => void,
+  onClickCardHeader: () => void,
 }
 
 const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
@@ -48,22 +71,39 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
     <Card className={classes.card} variant="outlined">
       <CardHeader
         className={classes.cardHeader}
-        avatar={<KeyboardBackspaceIcon className={classes.backIcon} onClick={props.onClickBackIcon} />}
-        title={`Your ${props.folderType} folders`}
+        avatar={<KeyboardBackspaceIcon className={classes.backIcon} />}
+        title={`Your ${props.folderType} submissions`}
         titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
+        onClick={props.onClickCardHeader}
       />
       <CardContent>
-        <TableContainer>
-          <Table aria-label="simple table">
+        <TableContainer component={Paper}>
+          <Table>
             <TableHead>
               <TableRow>
+                <TableCell align="left" colSpan={8} padding="none">
+                  <ListItem dense className={classes.tableHeader}>
+                    <ListItemIcon className={classes.tableIcon}>
+                      {props.folderType === "published" ? (
+                        <FolderIcon color="primary" />
+                      ) : (
+                        <FolderOpenIcon color="primary" />
+                      )}
+                    </ListItemIcon>
+                    <ListItemText primary={props.folderTitle} />
+                  </ListItem>
+                </TableCell>
+              </TableRow>
+              <TableRow>
                 {headRows.map((row, index) => (
-                  <TableCell key={index}>{row}</TableCell>
+                  <TableCell key={index} className={classes.headRows}>
+                    {row}
+                  </TableCell>
                 ))}
               </TableRow>
             </TableHead>
             <TableBody>
-              {props.bodyRows.map((row, index) => (
+              {props.bodyRows?.map((row, index) => (
                 <TableRow key={index}>
                   <TableCell component="th" scope="row">
                     {row.title}

--- a/src/components/Home/SubmissionDetailTable.js
+++ b/src/components/Home/SubmissionDetailTable.js
@@ -105,12 +105,18 @@ const SubmissionDetailTable = (props: SubmissionDetailTableProps) => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell align="left" colSpan={8} padding="none">
+                <TableCell colSpan={8} padding="none">
                   <ListItem dense className={classes.tableHeader}>
                     <ListItemIcon className={classes.tableIcon}>
                       {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                     </ListItemIcon>
                     <ListItemText primary={folderTitle} />
+                    <Button color="secondary" disabled>
+                      Edit
+                    </Button>
+                    <Button variant="contained" disabled>
+                      Publish
+                    </Button>
                   </ListItem>
                 </TableCell>
               </TableRow>

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -52,7 +52,7 @@ type SubmissionIndexCardProps = {
   folders: Array<any>,
   buttonTitle: string,
   onClickHeader?: () => void,
-  onClickContent: (folderId: string, folderType: string) => void,
+  onClickContent: (folderId: string, folderType: string) => Promise<void>,
   onClickButton: () => void,
 }
 

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -12,6 +12,7 @@ import ListItem from "@material-ui/core/ListItem"
 import ListItemIcon from "@material-ui/core/ListItemIcon"
 import ListItemText from "@material-ui/core/ListItemText"
 import { makeStyles } from "@material-ui/core/styles"
+import Typography from "@material-ui/core/Typography"
 import FolderIcon from "@material-ui/icons/Folder"
 import FolderOpenIcon from "@material-ui/icons/FolderOpen"
 
@@ -74,14 +75,9 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
   const classes = useStyles()
   const { folderType, folders, buttonTitle, onClickHeader, onClickContent, onClickButton } = props
 
-  return (
-    <Card className={classes.card} variant="outlined">
-      <CardHeader
-        title={folderType === "published" ? "Your Published Submissions" : "Your Draft Submissions"}
-        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
-        className={classes.cardTitle}
-        onClick={onClickHeader}
-      />
+  // Renders when there is folder list
+  const FolderList = () => (
+    <>
       <CardContent className={classes.cardContent}>
         <List>
           {folders.map((folder, index) => {
@@ -111,6 +107,27 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
           </Grid>
         )}
       </CardActions>
+    </>
+  )
+
+  // Renders when there is no folders in the list
+  const EmptyFolder = () => (
+    <CardContent className={classes.cardContent}>
+      <Typography align="center" variant="body2">
+        Currently there are no {folderType} submissions
+      </Typography>
+    </CardContent>
+  )
+
+  return (
+    <Card className={classes.card} variant="outlined">
+      <CardHeader
+        title={folderType === "published" ? "Your Published Submissions" : "Your Draft Submissions"}
+        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
+        className={classes.cardTitle}
+        onClick={onClickHeader}
+      />
+      {folders.length > 0 ? <FolderList /> : <EmptyFolder />}
     </Card>
   )
 }

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -27,6 +27,9 @@ const useStyles = makeStyles(theme => ({
     fontSize: "0.5em",
     padding: 0,
     marginTop: theme.spacing(1),
+    "&:hover": {
+      cursor: "pointer",
+    },
   },
   cardContent: {
     flexGrow: 1,
@@ -46,16 +49,16 @@ const useStyles = makeStyles(theme => ({
 
 type SubmissionIndexCardProps = {
   folderType: string,
-  folderTitles: Array<string>,
+  folders: Array<any>,
   buttonTitle: string,
-  onClickHeader: () => void,
-  onClickContent: () => void,
+  onClickHeader?: () => void,
+  onClickContent: (folderId: string, folderType: string) => void,
   onClickButton: () => void,
 }
 
 const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
   const classes = useStyles()
-  const { folderType, folderTitles, buttonTitle, onClickHeader, onClickContent, onClickButton } = props
+  const { folderType, folders, buttonTitle, onClickHeader, onClickContent, onClickButton } = props
 
   return (
     <Card className={classes.card} variant="outlined">
@@ -65,22 +68,28 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
         className={classes.cardTitle}
         onClick={onClickHeader}
       />
-      <CardContent className={classes.cardContent} onClick={onClickContent}>
+      <CardContent className={classes.cardContent}>
         <List>
-          {folderTitles.map((folderTitle, index) => {
+          {folders.map((folder, index) => {
             return (
-              <ListItem button key={index} dense className={classes.submissionsListItems}>
+              <ListItem
+                button
+                key={index}
+                dense
+                className={classes.submissionsListItems}
+                onClick={() => onClickContent(folder.folderId, folderType)}
+              >
                 <ListItemIcon className={classes.submissionsListIcon}>
                   {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                 </ListItemIcon>
-                <ListItemText primary={folderTitle} />
+                <ListItemText primary={folder.name} />
               </ListItem>
             )
           })}
         </List>
       </CardContent>
       <CardActions>
-        {folderTitles.length > 0 && (
+        {folders.length > 0 && (
           <Grid container alignItems="flex-start" justify="flex-end" direction="row">
             <Button variant="outlined" color="primary" onClick={onClickButton}>
               {buttonTitle}

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -47,9 +47,23 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+type ObjectInFolder = {
+  accessionId: string,
+  schema: string,
+}
+
+type Folder = {
+  folderId: string,
+  name: string,
+  description: string,
+  published: boolean,
+  drafts: Array<ObjectInFolder>,
+  metadataObjects: Array<ObjectInFolder>,
+}
+
 type SubmissionIndexCardProps = {
   folderType: string,
-  folders: Array<any>,
+  folders: Array<Folder>,
   buttonTitle: string,
   onClickHeader?: () => void,
   onClickContent: (folderId: string, folderType: string) => Promise<void>,

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -105,7 +105,7 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
       <CardActions>
         {folders.length > 0 && (
           <Grid container alignItems="flex-start" justify="flex-end" direction="row">
-            <Button variant="outlined" color="primary" onClick={onClickButton}>
+            <Button variant="outlined" color="primary" aria-label="Open or Close folders list" onClick={onClickButton}>
               {buttonTitle}
             </Button>
           </Grid>

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -111,7 +111,7 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
   )
 
   // Renders when there is no folders in the list
-  const EmptyFolder = () => (
+  const EmptyList = () => (
     <CardContent className={classes.cardContent}>
       <Typography align="center" variant="body2">
         Currently there are no {folderType} submissions
@@ -127,7 +127,7 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
         className={classes.cardTitle}
         onClick={onClickHeader}
       />
-      {folders.length > 0 ? <FolderList /> : <EmptyFolder />}
+      {folders.length > 0 ? <FolderList /> : <EmptyList />}
     </Card>
   )
 }

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -1,0 +1,95 @@
+//@flow
+import React from "react"
+
+import Button from "@material-ui/core/Button"
+import Card from "@material-ui/core/Card"
+import CardActions from "@material-ui/core/CardActions"
+import CardContent from "@material-ui/core/CardContent"
+import CardHeader from "@material-ui/core/CardHeader"
+import Grid from "@material-ui/core/Grid"
+import List from "@material-ui/core/List"
+import ListItem from "@material-ui/core/ListItem"
+import ListItemIcon from "@material-ui/core/ListItemIcon"
+import ListItemText from "@material-ui/core/ListItemText"
+import { makeStyles } from "@material-ui/core/styles"
+import FolderIcon from "@material-ui/icons/Folder"
+import FolderOpenIcon from "@material-ui/icons/FolderOpen"
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    border: "none",
+    padding: theme.spacing(0),
+  },
+  cardTitle: {
+    fontSize: "0.5em",
+    padding: 0,
+    marginTop: theme.spacing(1),
+  },
+  cardContent: {
+    flexGrow: 1,
+    padding: 0,
+  },
+  submissionsListItems: {
+    border: "solid 1px #ccc",
+    borderRadius: 3,
+    margin: theme.spacing(1, 0),
+    boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
+    alignItems: "flex-start",
+  },
+  submissionsListIcon: {
+    minWidth: 35,
+  },
+}))
+
+type SubmissionIndexCardProps = {
+  folderType: string,
+  folderTitles: Array<string>,
+  buttonTitle: string,
+  onClickHeader: () => void,
+  onClickContent: () => void,
+  onClickButton: () => void,
+}
+
+const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
+  const classes = useStyles()
+  const { folderType, folderTitles, buttonTitle, onClickHeader, onClickContent, onClickButton } = props
+
+  return (
+    <Card className={classes.card} variant="outlined">
+      <CardHeader
+        title={folderType === "published" ? "Your Published Submissions" : "Your Draft Submissions"}
+        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
+        className={classes.cardTitle}
+        onClick={onClickHeader}
+      />
+      <CardContent className={classes.cardContent} onClick={onClickContent}>
+        <List>
+          {folderTitles.map((folderTitle, index) => {
+            return (
+              <ListItem button key={index} dense className={classes.submissionsListItems}>
+                <ListItemIcon className={classes.submissionsListIcon}>
+                  {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
+                </ListItemIcon>
+                <ListItemText primary={folderTitle} />
+              </ListItem>
+            )
+          })}
+        </List>
+      </CardContent>
+      <CardActions>
+        {folderTitles.length > 0 && (
+          <Grid container alignItems="flex-start" justify="flex-end" direction="row">
+            <Button variant="outlined" color="primary" onClick={onClickButton}>
+              {buttonTitle}
+            </Button>
+          </Grid>
+        )}
+      </CardActions>
+    </Card>
+  )
+}
+
+export default SubmissionIndexCard

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -158,7 +158,7 @@ const WizardObjectIndex = () => {
   // Get draft objects of current folder
   // and count the amount of drafts of each existing objectType
   const draftObjects = folder.drafts
-    .map(draft => draft.schema)
+    ?.map(draft => draft.schema)
     .reduce((acc, val) => ((acc[val] = (acc[val] || 0) + 1), acc), {})
 
   const handlePanelChange = panel => (event, newExpanded) => {

--- a/src/features/publishedFoldersSlice.js
+++ b/src/features/publishedFoldersSlice.js
@@ -1,0 +1,16 @@
+//@flow
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = []
+
+const publishedFoldersSlice = createSlice({
+  name: "publishedFolders",
+  initialState,
+  reducers: {
+    setPublishedFolders: (state, action) => action.payload,
+    resetPublishedFolders: () => initialState,
+  },
+})
+
+export const { setPublishedFolders, resetPublishedFolders } = publishedFoldersSlice.actions
+export default publishedFoldersSlice.reducer

--- a/src/features/selectedFolderSlice.js
+++ b/src/features/selectedFolderSlice.js
@@ -1,5 +1,9 @@
 //@flow
 import { createSlice } from "@reduxjs/toolkit"
+import _reject from "lodash/reject"
+
+import draftAPIService from "services/draftAPI"
+import objectAPIService from "services/objectAPI"
 
 const initialState = {}
 
@@ -9,8 +13,46 @@ const selectedFolderSlice = createSlice({
   reducers: {
     setSelectedFolder: (state, action) => action.payload,
     resetSelectedFolder: () => initialState,
+    deleteFromAllObjects: (state, action) => {
+      state.allObjects = _reject(state.allObjects, function (o) {
+        return o.accessionId === action.payload
+      })
+    },
+    deleteDraftObject: (state, action) => {
+      state.drafts = _reject(state.drafts, function (o) {
+        return o.accessionId === action.payload
+      })
+    },
+    deleteMetadataObject: (state, action) => {
+      state.metadataObjects = _reject(state.metadataObjects, function (o) {
+        return o.accessionId === action.payload
+      })
+    },
   },
 })
 
-export const { setSelectedFolder, resetSelectedFolder } = selectedFolderSlice.actions
+export const {
+  setSelectedFolder,
+  resetSelectedFolder,
+  deleteFromAllObjects,
+  deleteDraftObject,
+  deleteMetadataObject,
+} = selectedFolderSlice.actions
 export default selectedFolderSlice.reducer
+
+// Delete object from selectedFolder only available for Unpublished folder atm
+export const deleteObjectFromSelectedFolder = (objectId: string, objectType: string, objectStatus: string) => async (
+  dispatch: any => void
+) => {
+  const service = objectStatus === "Draft" ? draftAPIService : objectAPIService
+  const response = await service.deleteObjectByAccessionId(objectType, objectId)
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      dispatch(deleteFromAllObjects(objectId))
+      objectStatus === "Draft" ? dispatch(deleteDraftObject(objectId)) : dispatch(deleteMetadataObject(objectId))
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
+}

--- a/src/features/selectedFolderSlice.js
+++ b/src/features/selectedFolderSlice.js
@@ -1,0 +1,16 @@
+//@flow
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = {}
+
+const selectedFolderSlice = createSlice({
+  name: "selectedFolder",
+  initialState,
+  reducers: {
+    setSelectedFolder: (state, action) => action.payload,
+    resetSelectedFolder: () => initialState,
+  },
+})
+
+export const { setSelectedFolder, resetSelectedFolder } = selectedFolderSlice.actions
+export default selectedFolderSlice.reducer

--- a/src/features/unpublishedFoldersSlice.js
+++ b/src/features/unpublishedFoldersSlice.js
@@ -27,7 +27,7 @@ type ObjectInFolder = {
   schema: string,
 }
 
-type DetailObject = {
+type ObjectDetails = {
   accessionId: string,
   lastModified: string,
   objectType: string,
@@ -42,13 +42,12 @@ type SelectedFolder = {
   published: boolean,
   drafts: Array<ObjectInFolder>,
   metadataObjects: Array<ObjectInFolder>,
-  allObjects?: Array<DetailObject>,
+  allObjects?: Array<ObjectDetails>,
 }
 
 export const updateFolderToUnpublishedFolders = (
   selectedFolder: SelectedFolder,
   objectId: string,
-  objectType: string,
   objectStatus: string
 ) => (dispatch: any => void) => {
   const updatedFolder =

--- a/src/features/unpublishedFoldersSlice.js
+++ b/src/features/unpublishedFoldersSlice.js
@@ -1,0 +1,16 @@
+//@flow
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = []
+
+const unpublishedFoldersSlice = createSlice({
+  name: "unpublishedFolders",
+  initialState,
+  reducers: {
+    setUnpublishedFolders: (state, action) => action.payload,
+    resetUnpublishedFolderss: () => initialState,
+  },
+})
+
+export const { setUnpublishedFolders, resetUnpublishedFolders } = unpublishedFoldersSlice.actions
+export default unpublishedFoldersSlice.reducer

--- a/src/features/unpublishedFoldersSlice.js
+++ b/src/features/unpublishedFoldersSlice.js
@@ -9,8 +9,35 @@ const unpublishedFoldersSlice = createSlice({
   reducers: {
     setUnpublishedFolders: (state, action) => action.payload,
     resetUnpublishedFolderss: () => initialState,
+    updateUnpublishedFolders: (state, action) => {
+      return state.map(folder => (folder.folderId === action.payload.folderId ? action.payload : folder))
+    },
   },
 })
 
-export const { setUnpublishedFolders, resetUnpublishedFolders } = unpublishedFoldersSlice.actions
+export const {
+  setUnpublishedFolders,
+  resetUnpublishedFolders,
+  updateUnpublishedFolders,
+} = unpublishedFoldersSlice.actions
 export default unpublishedFoldersSlice.reducer
+
+export const updateFolderToUnpublishedFolders = (
+  selectedFolder: any,
+  objectId: string,
+  objectType: string,
+  objectStatus: string
+) => (dispatch: any => void) => {
+  const updatedFolder =
+    objectStatus === "Draft"
+      ? {
+          ...selectedFolder,
+          drafts: selectedFolder.drafts.filter(draft => draft.accessionId !== objectId),
+        }
+      : {
+          ...selectedFolder,
+          metadataObjects: selectedFolder.metadataObjects.filter(obj => obj.accessionId !== objectId),
+        }
+  delete updatedFolder.allObjects
+  dispatch(updateUnpublishedFolders(updatedFolder))
+}

--- a/src/features/unpublishedFoldersSlice.js
+++ b/src/features/unpublishedFoldersSlice.js
@@ -22,8 +22,31 @@ export const {
 } = unpublishedFoldersSlice.actions
 export default unpublishedFoldersSlice.reducer
 
+type ObjectInFolder = {
+  accessionId: string,
+  schema: string,
+}
+
+type DetailObject = {
+  accessionId: string,
+  lastModified: string,
+  objectType: string,
+  status: string,
+  title: string,
+}
+
+type SelectedFolder = {
+  folderId: string,
+  name: string,
+  description: string,
+  published: boolean,
+  drafts: Array<ObjectInFolder>,
+  metadataObjects: Array<ObjectInFolder>,
+  allObjects?: Array<DetailObject>,
+}
+
 export const updateFolderToUnpublishedFolders = (
-  selectedFolder: any,
+  selectedFolder: SelectedFolder,
   objectId: string,
   objectType: string,
   objectStatus: string

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -34,7 +34,6 @@ export const fetchUserById = (userId: string) => async (dispatch: any => void) =
         drafts: response.data.drafts,
         folders: response.data.folders,
       }
-      console.log("response :>> ", response)
       dispatch(setUser(user))
       resolve(response)
     } else {

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -34,6 +34,7 @@ export const fetchUserById = (userId: string) => async (dispatch: any => void) =
         drafts: response.data.drafts,
         folders: response.data.folders,
       }
+      console.log("response :>> ", response)
       dispatch(setUser(user))
       resolve(response)
     } else {

--- a/src/rootReducer.js
+++ b/src/rootReducer.js
@@ -4,6 +4,7 @@ import { combineReducers } from "@reduxjs/toolkit"
 
 import draftStatusReducer from "features/draftStatusSlice"
 import publishedFoldersReducer from "features/publishedFoldersSlice"
+import selectedFolderReducer from "features/selectedFolderSlice"
 import unpublishedFoldersReducer from "features/unpublishedFoldersSlice"
 import userReducer from "features/userSlice"
 import wizardAlertReducer from "features/wizardAlertSlice"
@@ -26,6 +27,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   unpublishedFolders: unpublishedFoldersReducer,
   publishedFolders: publishedFoldersReducer,
+  selectedFolder: selectedFolderReducer,
 })
 
 export default rootReducer

--- a/src/rootReducer.js
+++ b/src/rootReducer.js
@@ -3,6 +3,8 @@
 import { combineReducers } from "@reduxjs/toolkit"
 
 import draftStatusReducer from "features/draftStatusSlice"
+import publishedFoldersReducer from "features/publishedFoldersSlice"
+import unpublishedFoldersReducer from "features/unpublishedFoldersSlice"
 import userReducer from "features/userSlice"
 import wizardAlertReducer from "features/wizardAlertSlice"
 import draftObjectReducer from "features/wizardDraftObjectSlice"
@@ -22,6 +24,8 @@ const rootReducer = combineReducers({
   draftStatus: draftStatusReducer,
   draftObject: draftObjectReducer,
   user: userReducer,
+  unpublishedFolders: unpublishedFoldersReducer,
+  publishedFolders: publishedFoldersReducer,
 })
 
 export default rootReducer

--- a/src/services/usersAPI.js
+++ b/src/services/usersAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
 
+import { errorMonitor } from "./errorMonitor"
+
 const api = create({ baseURL: "/users" })
+api.addMonitor(errorMonitor)
 
 const getUserById = async (userID: string) => {
   return await api.get(`/${userID}`)

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,5 +1,5 @@
 //@flow
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 
 import Button from "@material-ui/core/Button"
 import Card from "@material-ui/core/Card"
@@ -18,6 +18,7 @@ import FolderOpenIcon from "@material-ui/icons/FolderOpen"
 import { useDispatch, useSelector } from "react-redux"
 
 import { fetchUserById } from "features/userSlice"
+import folderAPIService from "services/folderAPI"
 
 const useStyles = makeStyles(theme => ({
   cardGrid: {
@@ -67,6 +68,7 @@ type SubmissionIndexCardProps = {
 const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
   const classes = useStyles()
   const { title, folderType, folderTitles } = props
+  console.log("folderTitles :>> ", folderTitles)
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader
@@ -76,9 +78,9 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
       />
       <CardContent className={classes.cardContent}>
         <List>
-          {folderTitles.map(folderTitle => {
+          {folderTitles.map((folderTitle, index) => {
             return (
-              <ListItem button key={folderTitle} dense className={classes.submissionsListItems}>
+              <ListItem button key={index} dense className={classes.submissionsListItems}>
                 <ListItemIcon className={classes.submissionsListIcon}>
                   {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
                 </ListItemIcon>
@@ -102,7 +104,12 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
 const Home = () => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.user)
+  console.log("user :>> ", user)
+  const folderIds = user.folders
+  // console.log("folderIds :>> ", folderIds)
   const classes = useStyles()
+  const [publishedFolders, setPublisedFolders] = useState([])
+
   const draftCard = [
     {
       title: "Your Draft Submissions",
@@ -114,13 +121,30 @@ const Home = () => {
     {
       title: "Your Published Submissions",
       folderType: "published",
-      submissions: ["Published1", "Published2", "Published3", "Published4", "Published5"],
+      submissions: publishedFolders,
     },
   ]
 
   useEffect(() => {
     dispatch(fetchUserById("current"))
   }, [])
+
+  useEffect(() => {
+    const fetchFolders = async () => {
+      const arr = []
+      if (folderIds) {
+        for (let i = 0; i < folderIds.length && i < 5; i += 1) {
+          const response = await folderAPIService.getFolderById(folderIds[i])
+          console.log("response :>> ", response)
+          if (response.ok) {
+            arr.push(response.data.name)
+          }
+        }
+        setPublisedFolders(arr)
+      }
+    }
+    fetchFolders()
+  }, folderIds)
 
   return (
     <Grid container direction="column" justify="space-between" alignItems="stretch">

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -213,6 +213,7 @@ const Home = () => {
       </Collapse>
     )
 
+  // Detail of selected folder, list all of its objects (draft + submitted)
   const SelectedFolderDetails = () => (
     <Collapse in={openSelectedFolder} collapsedHeight={0}>
       <SubmissionDetailTable

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -129,24 +129,25 @@ const Home = () => {
   }, [])
 
   useEffect(() => {
-    const fetchFolders = async () => {
-      const unpublishedArray = []
-      const publishedArray = []
-      if (folderIds) {
+    if (folderIds) {
+      const fetchFolders = async () => {
+        const unpublishedArray = []
+        const publishedArray = []
+
         for (let i = 0; i < folderIds.length; i += 1) {
           const response = await folderAPIService.getFolderById(folderIds[i])
-          if (response.ok && response.data.published && publishedArray.length <= 5) {
+          if (response.ok && response.data.published) {
             publishedArray.push(response.data.name)
-          } else if (response.ok && !response.data.published && unpublishedArray.length <= 5) {
+          } else if (response.ok && !response.data.published) {
             unpublishedArray.push(response.data.name)
           }
         }
         setUnpublishedFolders(unpublishedArray)
         setPublisedFolders(publishedArray)
       }
+      fetchFolders()
     }
-    fetchFolders()
-  }, [folderIds.join(",")])
+  }, [folderIds?.length])
 
   return (
     <Grid container direction="column" justify="space-between" alignItems="stretch">
@@ -159,7 +160,7 @@ const Home = () => {
             <SubmissionIndexCard
               title={card.title}
               folderType={card.folderType}
-              folderTitles={card.submissions}
+              folderTitles={card.submissions.slice(0, 5)}
               key={card.title}
             />
           </Grid>
@@ -172,7 +173,7 @@ const Home = () => {
             <SubmissionIndexCard
               title={card.title}
               folderType={card.folderType}
-              folderTitles={card.submissions}
+              folderTitles={card.submissions.slice(0, 5)}
               key={card.title}
             />
           </Grid>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -214,17 +214,18 @@ const Home = () => {
     )
 
   // Detail of selected folder, list all of its objects (draft + submitted)
-  const SelectedFolderDetails = () => (
-    <Collapse in={deepLevel === 3} collapsedHeight={0}>
-      <SubmissionDetailTable
-        bodyRows={selectedFolder.allObjects}
-        folderTitle={selectedFolder.name}
-        folderType={selectedFolder.published ? "published" : "draft"}
-        onClickCardHeader={handleGoBack}
-        onDelete={handleDeleteObject}
-      />
-    </Collapse>
-  )
+  const SelectedFolderDetails = () =>
+    deepLevel === 3 && (
+      <Collapse in={deepLevel === 3} collapsedHeight={0}>
+        <SubmissionDetailTable
+          bodyRows={selectedFolder.allObjects}
+          folderTitle={selectedFolder.name}
+          folderType={selectedFolder.published ? "published" : "draft"}
+          onClickCardHeader={handleGoBack}
+          onDelete={handleDeleteObject}
+        />
+      </Collapse>
+    )
 
   return (
     <Grid container direction="column" justify="space-between" alignItems="stretch">

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -77,13 +77,13 @@ const Home = () => {
     }
   }, [folderIds?.length])
 
-  const handleClickFolder = async (selectedFolderId: string, folderType: string) => {
+  const handleClickFolder = async (currentFolderId: string, folderType: string) => {
     setOpenSelectedFolder(true)
     const folders = folderType === "published" ? publishedFolders : unpublishedFolders
-    const selectedFolder = folders.find(folder => folder.folderId === selectedFolderId)
+    const currentFolder = folders.find(folder => folder.folderId === currentFolderId)
 
-    const draftObjects = selectedFolder?.drafts
-    const submittedObjects = selectedFolder?.metadataObjects
+    const draftObjects = currentFolder?.drafts
+    const submittedObjects = currentFolder?.metadataObjects
 
     setConnError(false)
 
@@ -97,14 +97,14 @@ const Home = () => {
         const response = await draftAPIService.getObjectByAccessionId(objectType, draftObjects[i].accessionId)
 
         if (response.ok) {
-          const draft = {
+          const draftObjectDetails = {
             accessionId: draftObjects[i].accessionId,
             title: response.data.descriptor?.studyTitle,
             objectType,
             status: "Draft",
             lastModified: response.data.dateModified,
           }
-          objectsArr.push(draft)
+          objectsArr.push(draftObjectDetails)
         } else {
           setConnError(true)
           setResponseError(response)
@@ -117,21 +117,21 @@ const Home = () => {
       const objectType = submittedObjects[j].schema
       const response = await objectAPIService.getObjectByAccessionId(objectType, submittedObjects[j].accessionId)
       if (response.ok) {
-        const submitted = {
+        const submittedObjectDetails = {
           accessionId: submittedObjects[j].accessionId,
           title: response.data.descriptor?.studyTitle,
           objectType,
           status: "Submitted",
           lastModified: response.data.dateModified,
         }
-        objectsArr.push(submitted)
+        objectsArr.push(submittedObjectDetails)
       } else {
         setConnError(true)
         setResponseError(response)
         setErrorPrefix("Fetching folder error.")
       }
     }
-    dispatch(setSelectedFolder({ ...selectedFolder, allObjects: objectsArr }))
+    dispatch(setSelectedFolder({ ...currentFolder, allObjects: objectsArr }))
   }
 
   // Handle from <SelectedFolderDetails /> back to <OverviewSubmissions />
@@ -147,7 +147,7 @@ const Home = () => {
       setResponseError(JSON.parse(error))
       setErrorPrefix("Can't delete object")
     })
-    dispatch(updateFolderToUnpublishedFolders(selectedFolder, objectId, objectType, objectStatus))
+    dispatch(updateFolderToUnpublishedFolders(selectedFolder, objectId, objectStatus))
   }
 
   // Contains both unpublished and published folders (max. 5 items/each)

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,24 +1,14 @@
 //@flow
 import React, { useEffect, useState } from "react"
 
-import Button from "@material-ui/core/Button"
-import Card from "@material-ui/core/Card"
-import CardActions from "@material-ui/core/CardActions"
-import CardContent from "@material-ui/core/CardContent"
-import CardHeader from "@material-ui/core/CardHeader"
 import CircularProgress from "@material-ui/core/CircularProgress"
 import Collapse from "@material-ui/core/Collapse"
 import Divider from "@material-ui/core/Divider"
 import Grid from "@material-ui/core/Grid"
-import List from "@material-ui/core/List"
-import ListItem from "@material-ui/core/ListItem"
-import ListItemIcon from "@material-ui/core/ListItemIcon"
-import ListItemText from "@material-ui/core/ListItemText"
 import { makeStyles } from "@material-ui/core/styles"
-import FolderIcon from "@material-ui/icons/Folder"
-import FolderOpenIcon from "@material-ui/icons/FolderOpen"
 import { useDispatch, useSelector } from "react-redux"
 
+import SubmissionIndexCard from "components/Home/SubmissionIndexCard"
 import WizardStatusMessageHandler from "components/NewDraftWizard/WizardForms/WizardStatusMessageHandler"
 import { setPublishedFolders } from "features/publishedFoldersSlice"
 import { setUnpublishedFolders } from "features/unpublishedFoldersSlice"
@@ -26,38 +16,8 @@ import { fetchUserById } from "features/userSlice"
 import folderAPIService from "services/folderAPI"
 
 const useStyles = makeStyles(theme => ({
-  cardGrid: {
-    paddingTop: theme.spacing(8),
-    paddingBottom: theme.spacing(8),
-  },
-  card: {
-    height: "100%",
-    display: "flex",
-    flexDirection: "column",
-    border: "none",
-    padding: theme.spacing(0),
-  },
-  cardTitle: {
-    fontSize: "0.5em",
-    padding: 0,
-    marginTop: theme.spacing(1),
-  },
-  cardContent: {
-    flexGrow: 1,
-    padding: 0,
-  },
   tableCard: {
     margin: theme.spacing(1, 0),
-  },
-  submissionsListItems: {
-    border: "solid 1px #ccc",
-    borderRadius: 3,
-    margin: theme.spacing(1, 0),
-    boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
-    alignItems: "flex-start",
-  },
-  submissionsListIcon: {
-    minWidth: 35,
   },
   loggedUser: {
     margin: theme.spacing(2, 0, 0),
@@ -66,54 +26,6 @@ const useStyles = makeStyles(theme => ({
     margin: theme.spacing(10, "auto"),
   },
 }))
-
-type SubmissionIndexCardProps = {
-  folderType: string,
-  folderTitles: Array<string>,
-  buttonTitle: string,
-  onClickHeader: () => void,
-  onClickContent: () => void,
-  onClickButton: () => void,
-}
-
-const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
-  const classes = useStyles()
-  const { folderType, folderTitles, buttonTitle, onClickHeader, onClickContent, onClickButton } = props
-
-  return (
-    <Card className={classes.card} variant="outlined">
-      <CardHeader
-        title={folderType === "published" ? "Your Published Submissions" : "Your Draft Submissions"}
-        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
-        className={classes.cardTitle}
-        onClick={onClickHeader}
-      />
-      <CardContent className={classes.cardContent} onClick={onClickContent}>
-        <List>
-          {folderTitles.map((folderTitle, index) => {
-            return (
-              <ListItem button key={index} dense className={classes.submissionsListItems}>
-                <ListItemIcon className={classes.submissionsListIcon}>
-                  {folderType === "published" ? <FolderIcon color="primary" /> : <FolderOpenIcon color="primary" />}
-                </ListItemIcon>
-                <ListItemText primary={folderTitle} />
-              </ListItem>
-            )
-          })}
-        </List>
-      </CardContent>
-      <CardActions>
-        {folderTitles.length > 0 && (
-          <Grid container alignItems="flex-start" justify="flex-end" direction="row">
-            <Button variant="outlined" color="primary" onClick={onClickButton}>
-              {buttonTitle}
-            </Button>
-          </Grid>
-        )}
-      </CardActions>
-    </Card>
-  )
-}
 
 const Home = () => {
   const dispatch = useDispatch()

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -182,34 +182,36 @@ const Home = () => {
     )
 
   // Full list of unpublished folders
-  const AllUnpublishedSubmissions = () => (
-    <Collapse in={deepLevel === 1} collapsedHeight={0} timeout={{ enter: 1500 }}>
-      <Grid item xs={12} className={classes.tableCard}>
-        <SubmissionIndexCard
-          folderType="unpublished"
-          folders={unpublishedFolders}
-          buttonTitle="Close"
-          onClickContent={handleClickFolder}
-          onClickButton={() => setDeepLevel(0)}
-        />
-      </Grid>
-    </Collapse>
-  )
+  const AllUnpublishedSubmissions = () =>
+    deepLevel === 1 && (
+      <Collapse in={deepLevel === 1} collapsedHeight={0} timeout={{ enter: 1500 }}>
+        <Grid item xs={12} className={classes.tableCard}>
+          <SubmissionIndexCard
+            folderType="unpublished"
+            folders={unpublishedFolders}
+            buttonTitle="Close"
+            onClickContent={handleClickFolder}
+            onClickButton={() => setDeepLevel(0)}
+          />
+        </Grid>
+      </Collapse>
+    )
 
   // Full list of published folders
-  const AllPublishedSubmissions = () => (
-    <Collapse in={deepLevel === 2} collapsedHeight={0} timeout={{ enter: 1500 }}>
-      <Grid item xs={12} className={classes.tableCard}>
-        <SubmissionIndexCard
-          folderType="published"
-          folders={publishedFolders}
-          buttonTitle="Close"
-          onClickContent={handleClickFolder}
-          onClickButton={() => setDeepLevel(0)}
-        />
-      </Grid>
-    </Collapse>
-  )
+  const AllPublishedSubmissions = () =>
+    deepLevel === 2 && (
+      <Collapse in={deepLevel === 2} collapsedHeight={0} timeout={{ enter: 1500 }}>
+        <Grid item xs={12} className={classes.tableCard}>
+          <SubmissionIndexCard
+            folderType="published"
+            folders={publishedFolders}
+            buttonTitle="Close"
+            onClickContent={handleClickFolder}
+            onClickButton={() => setDeepLevel(0)}
+          />
+        </Grid>
+      </Collapse>
+    )
 
   // Detail of selected folder, list all of its objects (draft + submitted)
   const SelectedFolderDetails = () => (

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -7,6 +7,7 @@ import CardActions from "@material-ui/core/CardActions"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
 import CircularProgress from "@material-ui/core/CircularProgress"
+import Collapse from "@material-ui/core/Collapse"
 import Divider from "@material-ui/core/Divider"
 import Grid from "@material-ui/core/Grid"
 import List from "@material-ui/core/List"
@@ -186,27 +187,31 @@ const Home = () => {
   )
 
   // Full list of unpublished folders
-  const allUnpublishedSubmissions = openAllUnpublished && (
-    <SubmissionIndexCard
-      folderType="unpublished"
-      folderTitles={unpublishedFolders}
-      buttonTitle="Close"
-      onClickHeader={() => {}}
-      onClickContent={() => {}}
-      onClickButton={() => setOpenAllUnpublished(false)}
-    />
+  const allUnpublishedSubmissions = (
+    <Collapse in={openAllUnpublished} collapsedHeight={0} timeout={{ enter: 1500 }}>
+      <SubmissionIndexCard
+        folderType="unpublished"
+        folderTitles={unpublishedFolders}
+        buttonTitle="Close"
+        onClickHeader={() => {}}
+        onClickContent={() => {}}
+        onClickButton={() => setOpenAllUnpublished(false)}
+      />
+    </Collapse>
   )
 
   // Full list of published folders
-  const allPublishedSubmissions = openAllPublished && (
-    <SubmissionIndexCard
-      folderType="publishedCard"
-      folderTitles={publishedFolders}
-      buttonTitle="Close"
-      onClickHeader={() => {}}
-      onClickContent={() => {}}
-      onClickButton={() => setOpenAllPublished(false)}
-    />
+  const allPublishedSubmissions = (
+    <Collapse in={openAllPublished} collapsedHeight={0} timeout={{ enter: 1500 }}>
+      <SubmissionIndexCard
+        folderType="publishedCard"
+        folderTitles={publishedFolders}
+        buttonTitle="Close"
+        onClickHeader={() => {}}
+        onClickContent={() => {}}
+        onClickButton={() => setOpenAllPublished(false)}
+      />
+    </Collapse>
   )
 
   return (

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -68,7 +68,7 @@ type SubmissionIndexCardProps = {
 const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
   const classes = useStyles()
   const { title, folderType, folderTitles } = props
-  console.log("folderTitles :>> ", folderTitles)
+
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader
@@ -104,17 +104,16 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
 const Home = () => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.user)
-  console.log("user :>> ", user)
   const folderIds = user.folders
-  // console.log("folderIds :>> ", folderIds)
   const classes = useStyles()
+  const [unpublishedFolders, setUnpublishedFolders] = useState([])
   const [publishedFolders, setPublisedFolders] = useState([])
 
   const draftCard = [
     {
       title: "Your Draft Submissions",
       folderType: "draft",
-      submissions: ["Title1", "Title2", "Title3", "Title4", "Title5"],
+      submissions: unpublishedFolders,
     },
   ]
   const publishedCard = [
@@ -131,20 +130,23 @@ const Home = () => {
 
   useEffect(() => {
     const fetchFolders = async () => {
-      const arr = []
+      const unpublishedArray = []
+      const publishedArray = []
       if (folderIds) {
-        for (let i = 0; i < folderIds.length && i < 5; i += 1) {
+        for (let i = 0; i < folderIds.length; i += 1) {
           const response = await folderAPIService.getFolderById(folderIds[i])
-          console.log("response :>> ", response)
-          if (response.ok) {
-            arr.push(response.data.name)
+          if (response.ok && response.data.published && publishedArray.length <= 5) {
+            publishedArray.push(response.data.name)
+          } else if (response.ok && !response.data.published && unpublishedArray.length <= 5) {
+            unpublishedArray.push(response.data.name)
           }
         }
-        setPublisedFolders(arr)
+        setUnpublishedFolders(unpublishedArray)
+        setPublisedFolders(publishedArray)
       }
     }
     fetchFolders()
-  }, folderIds)
+  }, [folderIds.join(",")])
 
   return (
     <Grid container direction="column" justify="space-between" alignItems="stretch">

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -91,7 +91,7 @@ const Home = () => {
 
     const objectsArr = []
 
-    if (folderType === "unpublished") {
+    if (folderType === "draft") {
       for (let i = 0; i < draftObjects?.length; i += 1) {
         const objectType = draftObjects[i].schema.includes("draft-")
           ? draftObjects[i].schema.substr(6)
@@ -159,7 +159,7 @@ const Home = () => {
       <>
         <Grid item xs={12} className={classes.tableCard}>
           <SubmissionIndexCard
-            folderType="unpublished"
+            folderType="draft"
             folders={unpublishedFolders.slice(0, 5)}
             buttonTitle="See all"
             onClickHeader={() => setDeepLevel(1)}
@@ -187,7 +187,7 @@ const Home = () => {
       <Collapse in={deepLevel === 1} collapsedHeight={0} timeout={{ enter: 1500 }}>
         <Grid item xs={12} className={classes.tableCard}>
           <SubmissionIndexCard
-            folderType="unpublished"
+            folderType="draft"
             folders={unpublishedFolders}
             buttonTitle="Close"
             onClickContent={handleClickFolder}

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -6,6 +6,7 @@ import Card from "@material-ui/core/Card"
 import CardActions from "@material-ui/core/CardActions"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
+import CircularProgress from "@material-ui/core/CircularProgress"
 import Divider from "@material-ui/core/Divider"
 import Grid from "@material-ui/core/Grid"
 import List from "@material-ui/core/List"
@@ -60,6 +61,9 @@ const useStyles = makeStyles(theme => ({
   loggedUser: {
     margin: theme.spacing(2, 0, 0),
   },
+  circularProgress: {
+    margin: theme.spacing(10, "auto"),
+  },
 }))
 
 type SubmissionIndexCardProps = {
@@ -98,11 +102,13 @@ const SubmissionIndexCard = (props: SubmissionIndexCardProps) => {
         </List>
       </CardContent>
       <CardActions>
-        <Grid container alignItems="flex-start" justify="flex-end" direction="row">
-          <Button variant="outlined" color="primary" onClick={onClickButton}>
-            {buttonTitle}
-          </Button>
-        </Grid>
+        {folderTitles.length > 0 && (
+          <Grid container alignItems="flex-start" justify="flex-end" direction="row">
+            <Button variant="outlined" color="primary" onClick={onClickButton}>
+              {buttonTitle}
+            </Button>
+          </Grid>
+        )}
       </CardActions>
     </Card>
   )
@@ -117,6 +123,7 @@ const Home = () => {
 
   const classes = useStyles()
 
+  const [isFetchingFolders, setFetchingFolders] = useState(true)
   const [openAllUnpublished, setOpenAllUnpublished] = useState(false)
   const [openAllPublished, setOpenAllPublished] = useState(false)
 
@@ -140,17 +147,19 @@ const Home = () => {
           } else {
             setConnError(true)
             setResponseError(response)
-            setErrorPrefix("Submissions fetching error.")
+            setErrorPrefix("Fetching folders error.")
           }
         }
         dispatch(setUnpublishedFolders(unpublishedArr))
         dispatch(setPublishedFolders(publishedArr))
+        setFetchingFolders(false)
       }
       fetchFolders()
     }
   }, [folderIds?.length])
 
-  const overviewSubmissions = !openAllUnpublished && !openAllPublished && (
+  // Contains both unpublished and published folders (max. 5 items/each)
+  const overviewSubmissions = !isFetchingFolders && !openAllUnpublished && !openAllPublished && (
     <>
       <Grid item xs={12} className={classes.tableCard}>
         <SubmissionIndexCard
@@ -176,6 +185,7 @@ const Home = () => {
     </>
   )
 
+  // Full list of unpublished folders
   const allUnpublishedSubmissions = openAllUnpublished && (
     <SubmissionIndexCard
       folderType="unpublished"
@@ -187,6 +197,7 @@ const Home = () => {
     />
   )
 
+  // Full list of published folders
   const allPublishedSubmissions = openAllPublished && (
     <SubmissionIndexCard
       folderType="publishedCard"
@@ -203,6 +214,8 @@ const Home = () => {
       <Grid item xs={12} className={classes.loggedUser}>
         Logged in as: {user.name}
       </Grid>
+
+      {isFetchingFolders && <CircularProgress className={classes.circularProgress} size={50} thickness={2.5} />}
       {overviewSubmissions}
       {allUnpublishedSubmissions}
       {allPublishedSubmissions}


### PR DESCRIPTION
### Description
- Draft and Published submissions are shown in Home Page
- User can navigate to see brief list to full list of folders
- Component for showing all of objects inside a specific folder
- Objects are able to be deleted inside a Draft folder

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/115

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Fetch and list maximum 5 items from Draft and Publish submission as an overview
- Button `See all` shows full list of folders in each submission type
- Button `Close` closes the full list and goes back to overview
- Click on a specific folder will open a table with details of objects in that folder
- Last modified date is formatted according to the design
- Add `/features/publishedFoldersSlice.js`, `/features/unpublishedFoldersSlice.js`, `/features/selectedFolderSlice.js`
- `components/Home/SubmissionIndexCard.js` to hold the list and `components/Home/SubmissionDetailTable.js` to hold the folder's objects' details
- Button `Delete` removes an object from a selected folder (applied for Draft/Unpublished folder only)
- Button `<-` to go back to folders list
- Add e2e test for Home

### Testing

- [x] e2e Test
- [x] Needs testing (start an issue or do a follow up PR about it)

### Mentions
According to the design:
- Selected Folder has buttons `Edit` and `Publish` but not do anything yet in this PR
- Objects in selected folder has functions `View`, `Edit`, `Delete` and `Show details` but only button `Delete` is implemented in this PR

