### PR TITLE
Use naming consistent with default behaviour

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     tty: true
     networks:
       # Change if using different network for backend container
-      - metadatasubmitter_default
+      - metadata-submitter_default
 
 networks:
-  metadatasubmitter_default:
+  metadata-submitter_default:
     external: true


### PR DESCRIPTION
### Description

Simplify for trying out setup with docker-compose by using the network
name docker will pick for backend by default if the repository has been
cloned without specifying the directory to clone to.

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues

<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

Changes network name used by docker-compose.
<!-- List changes made. -->

### Testing

Using this change, one can start without changing network names or using a specific name when cloning the backend.

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Unit Tests
- [ ] Integration Tests
- [  ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions

<!-- Shout outs to your friends that you made this happen or need help. -->
