### PR TITLE
Bugfix/restrict empty folder publish

### DIFF
--- a/src/__tests__/WizardFooter.test.js
+++ b/src/__tests__/WizardFooter.test.js
@@ -14,7 +14,7 @@ describe("WizardStepper", () => {
   let store
   let wrapper
 
-  beforeEach(() => {
+  it("should open dialog on click of cancel", () => {
     store = mockStore({
       submissionType: "form",
       wizardStep: 1,
@@ -26,12 +26,35 @@ describe("WizardStepper", () => {
         </Provider>
       </BrowserRouter>
     )
-  })
-
-  it("should open dialog on click of cancel", () => {
     render(wrapper)
     const button = screen.getByRole("button", { name: /Cancel/i })
     fireEvent.click(button)
     expect(screen.getByRole("dialog")).toBeDefined()
-  })
+  }),
+    it("should disable Publish button if there is no submitted objects", () => {
+      store = mockStore({
+        submissionType: "form",
+        wizardStep: 2,
+        submissionFolder: {
+          id: "FOL001",
+          name: "Test folder",
+          description: "Test folder",
+          published: false,
+          drafts: [],
+          metadataObjects: [],
+        },
+      })
+
+      wrapper = (
+        <BrowserRouter>
+          <Provider store={store}>
+            <WizardFooter />
+          </Provider>
+        </BrowserRouter>
+      )
+
+      render(wrapper)
+      const publishButton = screen.getByRole("button", { name: /Publish/i })
+      expect(publishButton).toBeDisabled()
+    })
 })

--- a/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
@@ -89,6 +89,18 @@ const WizardFooter = () => {
     setDialogOpen(false)
   }
 
+  const disablePublishButton = () => {
+    if (wizardStep !== 2) {
+      return true
+    }
+    if (wizardStep === 2) {
+      const { metadataObjects } = folder
+      if (metadataObjects.length === 0) {
+        return true
+      }
+    }
+  }
+
   return (
     <div>
       <div className={classes.phantom} />
@@ -132,7 +144,7 @@ const WizardFooter = () => {
             <Button
               variant="contained"
               color="primary"
-              disabled={wizardStep !== 2}
+              disabled={disablePublishButton()}
               onClick={() => {
                 setDialogOpen(true)
                 setAlertType("publish")


### PR DESCRIPTION
### Description

Publishing empty folders or folders with drafts is not possible. Only folders that have submitted objects can be published

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/133

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

- Add logic for disabling Publish button if folder is empty or no objects is submitted
- Add unit test for `WizardFooter.js`

### Testing

- [x] Unit Tests


