### PR TITLE
Added skip-links to submission types when navigation with keyboard

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -19,9 +19,12 @@ describe("Basic e2e", function () {
     cy.get("textarea[name='description']").type("Test description")
     cy.get("button[type=button]").contains("Next").click()
 
-    // Fill a Study form and submit object
+    // Skip-link
     cy.get("div[role=button]").contains("Study").click()
-    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("div[role=button]").contains("Fill Form").type("{enter}")
+    cy.get("div[role=button]").contains("Skip to form")
+
+    // Fill a Study form and submit object
     cy.get("input[name='descriptor.studyTitle']").type("Test title")
     cy.get("select[name='descriptor.studyType']").select("Metagenomics")
 

--- a/src/components/NewDraftWizard/WizardComponents/WizardAddObjectCard.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAddObjectCard.js
@@ -1,5 +1,5 @@
 //@flow
-import React from "react"
+import React, { useRef, useEffect } from "react"
 
 import Button from "@material-ui/core/Button"
 import Card from "@material-ui/core/Card"
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from "react-redux"
 import WizardDraftObjectPicker from "components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker"
 import WizardFillObjectDetailsForm from "components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm"
 import WizardUploadObjectXMLForm from "components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm"
+import { resetFocus } from "features/focusSlice"
 import { resetObjectType } from "features/wizardObjectTypeSlice"
 import { resetSubmissionType } from "features/wizardSubmissionTypeSlice"
 
@@ -54,6 +55,13 @@ const useStyles = makeStyles(theme => ({
 const CustomCardHeader = ({ title }: { title: string }) => {
   const classes = useStyles()
   const dispatch = useDispatch()
+  const focusTarget = useRef(null)
+  const shouldFocus = useSelector(state => state.focus)
+
+  useEffect(() => {
+    if (shouldFocus && focusTarget.current) focusTarget.current.focus()
+  }, [shouldFocus])
+
   return (
     <CardHeader
       title={title}
@@ -70,7 +78,11 @@ const CustomCardHeader = ({ title }: { title: string }) => {
           onClick={() => {
             dispatch(resetObjectType())
             dispatch(resetSubmissionType())
+            dispatch(resetFocus())
           }}
+          ref={focusTarget}
+          onBlur={() => dispatch(resetFocus())}
+          focusRipple={shouldFocus}
         >
           Hide
         </Button>

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from "react-redux"
 import WizardAlert from "./WizardAlert"
 
 import { resetDraftStatus } from "features/draftStatusSlice"
+import { setFocus } from "features/focusSlice"
 import { resetDraftObject } from "features/wizardDraftObjectSlice"
 import { setObjectType } from "features/wizardObjectTypeSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
@@ -45,6 +46,12 @@ const useStyles = makeStyles(theme => ({
   badge: {
     margin: theme.spacing(2, 2, 2, "auto"),
     zIndex: 0,
+  },
+  skipLink: {
+    color: theme.palette.primary.main,
+    "&:hover, &:focus": {
+      textDecoration: "underline",
+    },
   },
 }))
 
@@ -120,6 +127,53 @@ const SubmissionTypeList = ({
     existing: "Choose from drafts",
   }
   const classes = useStyles()
+  const [showSkipLink, setSkipLinkVisible] = useState(false)
+  const dispatch = useDispatch()
+
+  const handleSkipLink = event => {
+    if (event.key === "Enter") {
+      setSkipLinkVisible(true)
+    }
+  }
+
+  const toggleFocusWithEnter = event => {
+    if (event.key === "Enter") {
+      dispatch(setFocus())
+    }
+  }
+
+  const skipToSubmissionLink = () => {
+    let target = ""
+    switch (currentSubmissionType) {
+      case "form": {
+        target = "form"
+        break
+      }
+      case "xml": {
+        target = "XML upload"
+        break
+      }
+      case "existing": {
+        target = "drafts"
+        break
+      }
+      default: {
+        target = "main content"
+      }
+    }
+    return (
+      <a
+        className={classes.skipLink}
+        role="button"
+        tabIndex="0"
+        onBlur={() => setSkipLinkVisible(false)}
+        onClick={() => dispatch(setFocus())}
+        onKeyDown={event => toggleFocusWithEnter(event)}
+      >
+        Skip to {target}
+      </a>
+    )
+  }
 
   return (
     <List dense className={classes.submissionTypeList}>
@@ -129,10 +183,19 @@ const SubmissionTypeList = ({
           divider
           key={submissionType}
           button
-          onClick={() => handleSubmissionTypeChange(submissionType)}
+          onClick={event => {
+            handleSkipLink(event)
+            handleSubmissionTypeChange(submissionType)
+          }}
           className={classes.submissionTypeListItem}
         >
-          <ListItemText primary={submissionTypeMap[submissionType]} primaryTypographyProps={{ variant: "subtitle1" }} />
+          <ListItemText
+            primary={submissionTypeMap[submissionType]}
+            primaryTypographyProps={{ variant: "subtitle1" }}
+            secondary={
+              showSkipLink && isCurrentObjectType && currentSubmissionType === submissionType && skipToSubmissionLink()
+            }
+          />
         </ListItem>
       ))}
     </List>

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -96,7 +96,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
   const increment = useRef(null)
 
   const resetForm = () => {
-    methods.reset()
+    methods.reset(formSchema)
   }
 
   const checkDirty = () => {
@@ -256,7 +256,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
             className={classes.formButtonSubmit}
             onClick={() => {
               handleReset()
-              if (currentDraftId) handleDraftDelete(currentDraftId)
+              if (currentDraftId && methods.formState.isValid) handleDraftDelete(currentDraftId)
             }}
           >
             Submit {objectType}
@@ -304,7 +304,10 @@ const WizardFillObjectDetailsForm = () => {
           schema: objectType,
         })
       )
-        .then(() => setSuccessStatus("success"))
+        .then(() => {
+          setSuccessStatus("success")
+          dispatch(resetDraftStatus())
+        })
         .catch(error => {
           setSuccessStatus("error")
           setResponseInfo(error)
@@ -316,7 +319,6 @@ const WizardFillObjectDetailsForm = () => {
     }
     clearTimeout(waitForServertimer)
     setSubmitting(false)
-    dispatch(resetDraftStatus())
   }
 
   /*

--- a/src/features/focusSlice.js
+++ b/src/features/focusSlice.js
@@ -1,0 +1,16 @@
+//@flow
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = false
+
+const focusSlice = createSlice({
+  name: "focusSlice",
+  initialState,
+  reducers: {
+    setFocus: () => true,
+    resetFocus: () => initialState,
+  },
+})
+
+export const { setFocus, resetFocus } = focusSlice.actions
+export default focusSlice.reducer

--- a/src/rootReducer.js
+++ b/src/rootReducer.js
@@ -3,6 +3,7 @@
 import { combineReducers } from "@reduxjs/toolkit"
 
 import draftStatusReducer from "features/draftStatusSlice"
+import focusReducer from "features/focusSlice"
 import publishedFoldersReducer from "features/publishedFoldersSlice"
 import selectedFolderReducer from "features/selectedFolderSlice"
 import unpublishedFoldersReducer from "features/unpublishedFoldersSlice"
@@ -17,6 +18,7 @@ import submissionTypeReducer from "features/wizardSubmissionTypeSlice"
 
 const rootReducer = combineReducers({
   alert: wizardAlertReducer,
+  focus: focusReducer,
   statusDetails: wizardStatusMessageReducer,
   objectType: objectTypeReducer,
   wizardStep: wizardStepReducer,


### PR DESCRIPTION
### Description

Use skip-links in object index when navigating with keyboard.
Pressing `enter` in `submission type` shows skip-link to submission. Pressing `enter` in skip-link focuses `hide` button, for now. This is going to change when new submission controls are introduced in #135 

### Related issues

Fixes #98

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Slice for focus state
- Skip-links functionality in object index and object card components

### Testing

- [x] E2E tests
