### PR TITLE
Bugfix/too many api calls

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -126,7 +126,7 @@ describe("Home e2e", function () {
     cy.get("button[type=button]").contains("Publish").click()
     cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
 
-    cy.reload()
+    cy.get("div", { timeout: 10000 }).contains("Logged in as:")
     // Click "See all" button to navigate to all published folders list
     cy.get("div.MuiCardActions-root", { timeout: 30000 })
       .last()

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -144,6 +144,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
   useEffect(() => {
     window.addEventListener("keydown", keyHandler)
     return () => {
+      handleReset()
       window.removeEventListener("keydown", keyHandler)
     }
   }, [])

--- a/src/services/folderAPI.js
+++ b/src/services/folderAPI.js
@@ -22,9 +22,14 @@ const deleteFolderById = async (folderId: string) => {
   return await api.delete(`/${folderId}`)
 }
 
+const getFolders = async () => {
+  return await api.get()
+}
+
 export default {
   createNewFolder,
   getFolderById,
   patchFolderById,
   deleteFolderById,
+  getFolders,
 }


### PR DESCRIPTION
### Description

Home page used to make an API call for each folderID in user data. In this fix we get the data with single API call.

Original problem also introduced problems with async calls and component unmounting which resulted in React error messages for cleaning up `useEffect` -methods. This same behavior caused errors in auto-save feature in form submissions and was prone to memory leaks.

### Related issues

Fixes #150 and #151. Depending on https://github.com/CSCfi/metadata-submitter/pull/193

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Get folder and map folder data with single `GET` call to `/folders`
- Fixed auto-save timer reset problem in form submission.

### Testing

- [x] Tests do not apply
