### PR TITLE
Fix for saving multiple drafts when clicking Next and Back

### DIFF
--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -39,7 +39,7 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
 
   const onSubmit = data => {
     setConnError(false)
-    if (folder && (folder.name !== data.name || folder.description !== data.description)) {
+    if (folder && folder?.id) {
       dispatch(updateNewDraftFolder(folder.id, Object.assign({ ...data, folder })))
         .then(() => dispatch(increment()))
         .catch(() => setConnError(true))

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -74,6 +74,7 @@ export const createNewDraftFolder = (folderDetails: FolderFromForm) => async (di
     drafts: [],
   }
   const response = await folderAPIService.createNewFolder(folderForBackend)
+
   return new Promise((resolve, reject) => {
     if (response.ok) {
       const folder: Folder = {


### PR DESCRIPTION
### Description

Clicking `Next` and `Back` buttons multiple times would only save one version of the same draft folder

### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/145

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

- Replace logic for creating a new draft folder when clicking `Next` button, after giving folder's name and description

### Testing

- [x] Tests do not apply


