### PR TITLE
Bugfix/check empty form

### DIFF
--- a/cypress/integration/emptyForm.spec.js
+++ b/cypress/integration/emptyForm.spec.js
@@ -1,0 +1,56 @@
+describe("empty form should not be alerted or saved", function () {
+  const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
+
+  it("should not show draft saving alert when form is empty, should not save an empty form", () => {
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.visit(baseUrl + "newdraft")
+
+    // Navigate to folder creation
+    cy.get("button[type=button]").contains("New folder").click()
+
+    // Add folder name & description, navigate to submissions
+    cy.get("input[name='name']").type("Test name")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Focus on the Study title input in the Study form (not type anything)
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").focus()
+
+    // Switch to "Upload XML File" and Alert window should not pop up
+    cy.get("div[role=button]").contains("Upload XML File").click()
+    cy.get("form", { timeout: 10000 }).should("be.visible")
+    cy.get("form").within(() => {
+      cy.get("input[placeholder='Name']").should("be.visible")
+    })
+
+    // Switch back to "Fill form" and fill it
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Test study")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test study")
+
+    // Clear form and Save
+    cy.get("button[type=button]").contains("Clear form").click()
+    cy.get("input[name='descriptor.studyTitle']", { timeout: 10000 }).should("be.empty")
+    cy.get("button[type=button]").contains("Save as Draft").click()
+
+    // Expect Info window should pop up
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("An empty form cannot be saved.").should("be.visible")
+
+    // Fill in Form and Save
+    cy.get("input[name='descriptor.studyTitle']").type("Test study")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test study")
+    cy.get("button[type=button]").contains("Save as Draft").click()
+
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Clear Study title input and Save
+    cy.get("input[name='descriptor.studyTitle']").clear()
+    cy.get("button[type=button]").contains("Save as Draft").click()
+
+    // Expect Info window should pop up
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("An empty form cannot be saved.").should("be.visible")
+  })
+})

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -200,6 +200,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
 
   const resetForm = () => {
     methods.reset(formSchema)
+    setCleanedValues({})
     dispatch(resetDraftStatus())
     handleReset()
   }

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -200,6 +200,8 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
 
   const resetForm = () => {
     methods.reset(formSchema)
+    dispatch(resetDraftStatus())
+    handleReset()
   }
 
   // Check if the form is empty
@@ -339,7 +341,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
     if (alert) {
       clearInterval(increment.current)
     }
-    if (timer >= 5) {
+    if (timer >= 60) {
       saveDraft()
       clearInterval(increment.current)
     }

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -90,7 +90,6 @@ const useStyles = makeStyles(theme => ({
 
 type CustomCardHeaderProps = {
   objectType: string,
-  title: string,
   onClickNewForm: () => void,
   onClickClearForm: () => void,
   onClickSaveDraft: () => Promise<void>,
@@ -111,7 +110,7 @@ type FormContentProps = {
  */
 const CustomCardHeader = (props: CustomCardHeaderProps) => {
   const classes = useStyles()
-  const { objectType, title, refForm, onClickNewForm, onClickClearForm, onClickSaveDraft, onClickSubmit } = props
+  const { objectType, refForm, onClickNewForm, onClickClearForm, onClickSaveDraft, onClickSubmit } = props
 
   const dispatch = useDispatch()
 
@@ -161,7 +160,7 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
 
   return (
     <CardHeader
-      title={title}
+      title="Fill form"
       titleTypographyProps={{ variant: "inherit" }}
       classes={{
         root: classes.cardHeader,
@@ -203,8 +202,13 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
     methods.reset(formSchema)
   }
 
+  // Check if the form is empty
+  const checkFormCleanedValuesEmpty = (cleanedValues: any) => {
+    return Object.keys(cleanedValues).length > 0
+  }
+
   const checkDirty = () => {
-    if (methods.formState.isDirty && draftStatus === "") {
+    if (methods.formState.isDirty && draftStatus === "" && checkFormCleanedValuesEmpty(cleanedValues)) {
       dispatch(setDraftStatus("notSaved"))
     }
   }
@@ -216,8 +220,14 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
   const handleChange = () => {
     const values = JSONSchemaParser.cleanUpFormValues(methods.getValues())
     setCleanedValues(values)
-    dispatch(setDraftObject(Object.assign(values, { draftId: currentDraftId })))
-    checkDirty()
+
+    if (checkFormCleanedValuesEmpty(values)) {
+      dispatch(setDraftObject(Object.assign(values, { draftId: currentDraftId })))
+      checkDirty()
+    } else {
+      dispatch(resetDraftStatus())
+      handleReset()
+    }
   }
 
   const handleDraftDelete = draftId => {
@@ -254,64 +264,74 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
 
   const saveDraft = async () => {
     handleReset()
-    if (currentDraftId || draftObject.accessionId) {
-      const response = await draftAPIService.patchFromJSON(objectType, currentDraftId, cleanedValues)
-      if (response.ok) {
-        dispatch(resetDraftStatus())
-        dispatch(
-          updateStatus({
-            successStatus: "success",
-            response: response,
-            errorPrefix: "",
-          })
-        )
+    if (checkFormCleanedValuesEmpty(cleanedValues)) {
+      if (currentDraftId || draftObject.accessionId) {
+        const response = await draftAPIService.patchFromJSON(objectType, currentDraftId, cleanedValues)
+        if (response.ok) {
+          dispatch(resetDraftStatus())
+          dispatch(
+            updateStatus({
+              successStatus: "success",
+              response: response,
+              errorPrefix: "",
+            })
+          )
+        } else {
+          dispatch(
+            updateStatus({
+              successStatus: "error",
+              response: response,
+              errorPrefix: "Unexpected error",
+            })
+          )
+        }
       } else {
-        dispatch(
-          updateStatus({
-            successStatus: "error",
-            response: response,
-            errorPrefix: "Unexpected error",
-          })
-        )
+        const response = await draftAPIService.createFromJSON(objectType, cleanedValues)
+        if (response.ok) {
+          setCurrentDraftId(response.data.accessionId)
+          dispatch(resetDraftStatus())
+          dispatch(
+            addObjectToDrafts(folderId, {
+              accessionId: response.data.accessionId,
+              schema: "draft-" + objectType,
+            })
+          )
+            .then(() => {
+              dispatch(
+                updateStatus({
+                  successStatus: "success",
+                  response: response,
+                  errorPrefix: "",
+                })
+              )
+            })
+            .catch(error => {
+              dispatch(
+                updateStatus({
+                  successStatus: "error",
+                  response: error,
+                  errorPrefix: "Cannot connect to folder API",
+                })
+              )
+            })
+        } else {
+          dispatch(
+            updateStatus({
+              successStatus: "error",
+              response: response,
+              errorPrefix: "Unexpected error",
+            })
+          )
+        }
       }
     } else {
-      const response = await draftAPIService.createFromJSON(objectType, cleanedValues)
-      if (response.ok) {
-        setCurrentDraftId(response.data.accessionId)
-        dispatch(resetDraftStatus())
-        dispatch(
-          addObjectToDrafts(folderId, {
-            accessionId: response.data.accessionId,
-            schema: "draft-" + objectType,
-          })
-        )
-          .then(() => {
-            dispatch(
-              updateStatus({
-                successStatus: "success",
-                response: response,
-                errorPrefix: "",
-              })
-            )
-          })
-          .catch(error => {
-            dispatch(
-              updateStatus({
-                successStatus: "error",
-                response: error,
-                errorPrefix: "Cannot connect to folder API",
-              })
-            )
-          })
-      } else {
-        dispatch(
-          updateStatus({
-            successStatus: "error",
-            response: response,
-            errorPrefix: "Unexpected error",
-          })
-        )
-      }
+      dispatch(
+        updateStatus({
+          successStatus: "info",
+          response: "",
+          errorPrefix: "An empty form cannot be saved. Please fill in the form before saving it.",
+        })
+      )
     }
   }
 
@@ -319,7 +339,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
     if (alert) {
       clearInterval(increment.current)
     }
-    if (timer >= 60) {
+    if (timer >= 5) {
       saveDraft()
       clearInterval(increment.current)
     }
@@ -335,7 +355,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId }: F
     <FormProvider {...methods}>
       <CustomCardHeader
         objectType={objectType}
-        title="Fill form"
         refForm="hook-form"
         onClickNewForm={() => createNewForm()}
         onClickClearForm={() => resetForm()}

--- a/src/components/NewDraftWizard/WizardForms/WizardStatusMessageHandler.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardStatusMessageHandler.js
@@ -40,14 +40,18 @@ const ErrorHandler = ({
 }
 
 // Info messages
-const InfoHandler = ({ handleClose }: { handleClose: boolean => void }) => {
-  const message = `For some reason, your file is still being saved
+const InfoHandler = ({ handleClose, prefixText }: { handleClose: boolean => void, prefixText?: string }) => {
+  const defaultMessage = `For some reason, your file is still being saved
   to our database, please wait. If saving doesn't go through in two
   minutes, please try saving the file again.`
 
+  const messageTemplate = (prefixText?: string) => {
+    return prefixText ? prefixText : defaultMessage
+  }
+
   return (
     <Alert onClose={() => handleClose(false)} severity="info">
-      {message}
+      {messageTemplate(prefixText)}
     </Alert>
   )
 }
@@ -81,7 +85,7 @@ const WizardStatusMessageHandler = ({
       case "success":
         return <SuccessHandler handleClose={handleClose} response={response} />
       case "info":
-        return <InfoHandler handleClose={handleClose} />
+        return <InfoHandler handleClose={handleClose} prefixText={prefixText} />
       case "error":
         return <ErrorHandler handleClose={handleClose} response={response} prefixText={prefixText} />
       default:


### PR DESCRIPTION
### Description

- An empty form should not be auto saved or `Save as Draft`
- `Clear form` button should reset the `formValues`, set `isDirty` false, and cannot be `Save as Draft` after that
- Open a form, click on a form field, and change submissionType should not open the Draft saving dialog (bug https://github.com/CSCfi/metadata-submitter-frontend/issues/127)

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/127

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Changes Made

- Update logic for `saveDraft`, `checkDirty`, and `resetForm` functions in `WizardFillObjectDetailsForm` component
- Update `InfoHandler` regarding to information when saving an empty form in `WizardStatusMessageHandler` component
- Add e2e test for **emptyForm**

### Testing

- [x] Integration Tests



