### PR TITLE
Test snackbar alert when replacing XML file

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -76,6 +76,7 @@ describe("Basic e2e", function () {
     })
     cy.get("form").submit()
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
+    cy.contains(".MuiAlert-message", "Object replaced")
 
     // Fill an Analysis form and submit object
     cy.get("div[role=button]").contains("Analysis").click()


### PR DESCRIPTION
### Description

Cypress test for replacing XML file doesn't get `snackbar` alert message after replace when ran through GH actions.
Check against element for this message.

### Related issues

Fixed #160

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Added test for snackbar alert element
