### PR TITLE
Custom hook for draft saving

### DIFF
--- a/cypress/integration/draft.spec.js
+++ b/cypress/integration/draft.spec.js
@@ -52,7 +52,7 @@ describe("Draft operations", function () {
     cy.get("input[name='descriptor.studyTitle']").type("New title")
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title")
     cy.get("select[name='descriptor.studyType']").select("Metagenomics")
-    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("button[type=button]").contains("Update draft").click()
 
     // Create a new form and save as draft
     cy.get("button").contains("New form").click()

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
@@ -81,7 +81,7 @@ const WizardDraftObjectPicker = (): Node => {
     setConnError(false)
     const response = await draftAPIService.getObjectByAccessionId(objectType, objectId)
     if (response.ok) {
-      dispatch(setCurrentObject({ ...response.data, type: ObjectStatus.draft }))
+      dispatch(setCurrentObject({ ...response.data, status: ObjectStatus.draft }))
       dispatch(setSubmissionType(ObjectSubmissionTypes.form))
     } else {
       setConnError(true)

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectActions.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectActions.js
@@ -46,7 +46,7 @@ const WizardSavedObjectActions = (props: WizardSavedObjectActionsProps): React$E
       dispatch(
         setCurrentObject({
           ...response.data,
-          type: ObjectStatus.submitted,
+          status: ObjectStatus.submitted,
           tags: props.tags,
           index: props.submissions.findIndex(item => item.accessionId === props.objectId),
         })

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -14,6 +14,8 @@ import { cloneDeep } from "lodash"
 import { useForm, FormProvider } from "react-hook-form"
 import { useDispatch, useSelector } from "react-redux"
 
+import saveDraftHook from "../WizardHooks/WizardSaveDraftHook"
+
 import { WizardAjvResolver } from "./WizardAjvResolver"
 import JSONSchemaParser from "./WizardJSONSchemaParser"
 import WizardStatusMessageHandler from "./WizardStatusMessageHandler"
@@ -24,8 +26,7 @@ import { setDraftStatus, resetDraftStatus } from "features/draftStatusSlice"
 import { resetFocus } from "features/focusSlice"
 import { setCurrentObject, resetCurrentObject } from "features/wizardCurrentObjectSlice"
 import { updateStatus } from "features/wizardStatusMessageSlice"
-import { addObjectToFolder, addObjectToDrafts, deleteObjectFromFolder } from "features/wizardSubmissionFolderSlice"
-import draftAPIService from "services/draftAPI"
+import { addObjectToFolder, deleteObjectFromFolder } from "features/wizardSubmissionFolderSlice"
 import objectAPIService from "services/objectAPI"
 import schemaAPIService from "services/schemaAPI"
 
@@ -156,17 +157,17 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
         Clear form
       </Button>
       <Button variant="contained" aria-label="save form as draft" size="small" onClick={onClickSaveDraft}>
-        Save as Draft
+        {currentObject?.status === "Draft" ? "Update draft" : " Save as Draft"}
       </Button>
       <Button
         variant="contained"
         aria-label="submit form"
         size="small"
-        type={currentObject?.type === ObjectStatus.submitted ? "button" : "submit"}
+        type={currentObject?.status === ObjectStatus.submitted ? "button" : "submit"}
         onClick={onClickSubmit}
         form={refForm}
       >
-        {currentObject?.type === ObjectStatus.submitted ? "Update" : "Submit"} {objectType}
+        {currentObject?.status === ObjectStatus.submitted ? "Update" : "Submit"} {objectType}
       </Button>
     </div>
   )
@@ -255,7 +256,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
             setCurrentObject({
               ...clone,
               cleanedValues: values,
-              type: currentObject.type || ObjectStatus.draft,
+              status: currentObject.status || ObjectStatus.draft,
               objectId: currentObjectId,
             })
           )
@@ -346,47 +347,16 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   const saveDraft = async () => {
     resetTimer()
     if (checkFormCleanedValuesEmpty(cleanedValues)) {
-      if ((currentObjectId || currentObject?.accessionId) && currentObject?.type === ObjectStatus.draft) {
-        const response = await draftAPIService.patchFromJSON(objectType, currentObjectId, cleanedValues)
-        patchHandler(response)
-      } else {
-        const response = await draftAPIService.createFromJSON(objectType, cleanedValues)
-        if (response.ok) {
-          if (currentObject?.type !== ObjectStatus.submitted) setCurrentObjectId(response.data.accessionId)
-          dispatch(resetDraftStatus())
-          dispatch(
-            addObjectToDrafts(folderId, {
-              accessionId: response.data.accessionId,
-              schema: "draft-" + objectType,
-            })
-          )
-            .then(() => {
-              dispatch(
-                updateStatus({
-                  successStatus: WizardStatus.success,
-                  response: response,
-                  errorPrefix: "",
-                })
-              )
-            })
-            .catch(error => {
-              dispatch(
-                updateStatus({
-                  successStatus: WizardStatus.error,
-                  response: error,
-                  errorPrefix: "Cannot connect to folder API",
-                })
-              )
-            })
-        } else {
-          dispatch(
-            updateStatus({
-              successStatus: WizardStatus.error,
-              response: response,
-              errorPrefix: "Unexpected error",
-            })
-          )
-        }
+      const handleSave = await saveDraftHook(
+        currentObject.accessionId || currentObject.objectId,
+        objectType,
+        currentObject.status,
+        folderId,
+        currentObject.cleanedValues || currentObject,
+        dispatch
+      )
+      if (handleSave.ok && currentObject?.status !== ObjectStatus.submitted) {
+        setCurrentObjectId(handleSave.data.accessionId)
       }
     } else {
       dispatch(
@@ -406,8 +376,8 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   }
 
   const submitForm = () => {
-    if (currentObject?.type === ObjectStatus.submitted) patchObject()
-    if (currentObject?.type === ObjectStatus.draft && currentObjectId && Object.keys(currentObject).length > 0)
+    if (currentObject?.status === ObjectStatus.submitted) patchObject()
+    if (currentObject?.status === ObjectStatus.draft && currentObjectId && Object.keys(currentObject).length > 0)
       handleDraftDelete(currentObjectId)
 
     resetTimer()

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -157,7 +157,7 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
         Clear form
       </Button>
       <Button variant="contained" aria-label="save form as draft" size="small" onClick={onClickSaveDraft}>
-        {currentObject?.status === "Draft" ? "Update draft" : " Save as Draft"}
+{currentObject?.status === ObjectStatus.draft ? "Update draft" : " Save as Draft"}
       </Button>
       <Button
         variant="contained"

--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -161,7 +161,7 @@ const WizardUploadObjectXMLForm = (): React$Element<typeof Container> => {
       disabled={isSubmitting || !watchFile || watchFile.length === 0 || errors.fileUpload != null}
       onClick={handleSubmit(onSubmit)}
     >
-      {currentObject?.type === ObjectStatus.submitted ? "Replace" : "Submit"}
+      {currentObject?.status === ObjectStatus.submitted ? "Replace" : "Submit"}
     </Button>
   )
 

--- a/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
+++ b/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
@@ -1,0 +1,75 @@
+//@flow
+import { ObjectStatus } from "constants/wizardObject"
+import { WizardStatus } from "constants/wizardStatus"
+import { resetDraftStatus } from "features/draftStatusSlice"
+import { resetCurrentObject } from "features/wizardCurrentObjectSlice"
+import { updateStatus } from "features/wizardStatusMessageSlice"
+import { addObjectToDrafts } from "features/wizardSubmissionFolderSlice"
+import draftAPIService from "services/draftAPI"
+
+const saveDraftHook = async (
+  accessionId?: string,
+  objectType: string,
+  objectStatus: string,
+  folderId: string,
+  values: any,
+  dispatch: function
+): any => {
+  if (accessionId && objectStatus === ObjectStatus.draft) {
+    const response = await draftAPIService.patchFromJSON(objectType, accessionId, values)
+    if (response.ok) {
+      dispatch(resetDraftStatus())
+      dispatch(
+        updateStatus({
+          successStatus: WizardStatus.success,
+          response: response,
+          errorPrefix: "",
+        })
+      )
+      dispatch(resetCurrentObject())
+
+      return response
+    } else {
+      dispatch(
+        updateStatus({
+          successStatus: WizardStatus.error,
+          response: response,
+          errorPrefix: "Cannot save draft",
+        })
+      )
+      return response
+    }
+  } else {
+    const response = await draftAPIService.createFromJSON(objectType, values)
+    if (response.ok) {
+      dispatch(
+        updateStatus({
+          successStatus: WizardStatus.success,
+          response: response,
+          errorPrefix: "",
+        })
+      )
+      dispatch(resetDraftStatus())
+      dispatch(
+        addObjectToDrafts(folderId, {
+          accessionId: response.data.accessionId,
+          schema: "draft-" + objectType,
+        })
+      )
+      dispatch(resetCurrentObject())
+
+      return response
+    } else {
+      dispatch(
+        updateStatus({
+          successStatus: WizardStatus.error,
+          response: response,
+          errorPrefix: "Cannot save draft",
+        })
+      )
+      return response
+    }
+  }
+}
+
+export default saveDraftHook


### PR DESCRIPTION
### Description

Custom hook for reducing duplicate code for draft saving logic in both `WizardFillObjectDetailsForm` and `WizardAlert` components.

### Related issues

Closes #129 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Separate draft save logic into dedicated hook
- Renamed `currentObject.type` property to `currentObject.status` since this name more corresponding
- Display `Update a draft` instead of `Save as Draft` in form action button when editing a draft.

### Testing

- [x] Tests do not apply
