### PR TITLE
Feature/display object titles

### DIFF
--- a/cypress/integration/objectTitles.spec.js
+++ b/cypress/integration/objectTitles.spec.js
@@ -1,0 +1,83 @@
+describe("draft and submitted objects' titles", function () {
+  const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
+
+  beforeEach(() => {
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.visit(baseUrl + "newdraft")
+
+    // Navigate to folder creation
+    cy.get("button[type=button]").contains("New folder").click()
+    // Add folder name & description, navigate to submissions
+    cy.get("input[name='name']").type("Test name")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+  })
+
+  it("should show correct Submitted object's displayTitle", () => {
+    // Focus on the Study title input in the Study form (not type anything)
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+
+    // Fill a Study form and submit object
+    cy.get("input[name='descriptor.studyTitle']").type("Test title")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title")
+    cy.get("select[name='descriptor.studyType']").select("Metagenomics")
+
+    // Submit form
+    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Check the submitted object has correct displayTitle
+    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title")
+
+    // Edit submitted object
+    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title")
+    cy.get("input[name='descriptor.studyTitle']").type(" 2").blur()
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title 2")
+    cy.get("button[type=button]").contains("Update").click()
+    cy.get("div[role=alert]").contains("Object updated")
+
+    // Check the submitted object has correctly updated displayTitle
+    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+
+    // Navigate to summary
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Check the submitted object has correct displayTitle
+    cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
+    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+  })
+
+  it("should show correct Draft object's displayTitle", () => {
+    // Focus on the Study title input in the Study form (not type anything)
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+
+    // Fill a Study form and submit object
+    cy.get("input[name='descriptor.studyTitle']").type("Draft title")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Draft title")
+    cy.get("select[name='descriptor.studyType']").select("Metagenomics")
+
+    // Save a draft
+    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+    cy.get("div[role=button]").contains("Choose from drafts").click()
+    cy.get("div[data-testid=Existing").find("li").should("have.length", 1)
+
+    // Check the draft object has correct displayTitle
+    cy.get("div[data-testid='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title")
+
+    // Edit draft object's title
+    cy.get("button[aria-label='Continue draft']").first().click()
+    cy.get("input[name='descriptor.studyTitle']").type(" 2")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Draft title 2")
+    cy.get("button[type=button]").contains("Update draft").click()
+
+    // Check the draft object has correctly updated displayTitle
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft updated")
+    cy.get("div[role=button]").contains("Choose from drafts").click()
+    cy.get("div[data-testid='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title 2")
+  })
+})

--- a/cypress/integration/objectTitles.spec.js
+++ b/cypress/integration/objectTitles.spec.js
@@ -29,7 +29,7 @@ describe("draft and submitted objects' titles", function () {
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
     // Check the submitted object has correct displayTitle
-    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title")
+    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title")
 
     // Edit submitted object
     cy.get("button[type=button]").contains("Edit").click()
@@ -40,14 +40,14 @@ describe("draft and submitted objects' titles", function () {
     cy.get("div[role=alert]").contains("Object updated")
 
     // Check the submitted object has correctly updated displayTitle
-    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
 
     // Navigate to summary
     cy.get("button[type=button]").contains("Next").click()
 
     // Check the submitted object has correct displayTitle
     cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
-    cy.get("div[data-testid='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
   })
 
   it("should show correct Draft object's displayTitle", () => {
@@ -67,7 +67,7 @@ describe("draft and submitted objects' titles", function () {
     cy.get("div[data-testid=Existing").find("li").should("have.length", 1)
 
     // Check the draft object has correct displayTitle
-    cy.get("div[data-testid='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title")
+    cy.get("div[data-schema='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title")
 
     // Edit draft object's title
     cy.get("button[aria-label='Continue draft']").first().click()
@@ -78,6 +78,6 @@ describe("draft and submitted objects' titles", function () {
     // Check the draft object has correctly updated displayTitle
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft updated")
     cy.get("div[role=button]").contains("Choose from drafts").click()
-    cy.get("div[data-testid='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title 2")
+    cy.get("div[data-schema='draft-study']", { timeout: 10000 }).should("contain.text", "Draft title 2")
   })
 })

--- a/src/__tests__/WizardDraftObjectPicker.test.js
+++ b/src/__tests__/WizardDraftObjectPicker.test.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import "@testing-library/jest-dom/extend-expect"
 import { ThemeProvider } from "@material-ui/core/styles"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { Provider } from "react-redux"
 import configureStore from "redux-mock-store"
 import thunk from "redux-thunk"
@@ -25,8 +25,16 @@ describe("WizardStepper", () => {
       name: "Testname",
       published: false,
       drafts: [
-        { accessionId: "TESTID1", schema: `draft-${ObjectTypes.study}` },
-        { accessionId: "TESTID2", schema: `draft-${ObjectTypes.study}` },
+        {
+          accessionId: "TESTID1",
+          schema: `draft-${ObjectTypes.study}`,
+          tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Study form 1" },
+        },
+        {
+          accessionId: "TESTID2",
+          schema: `draft-${ObjectTypes.study}`,
+          tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Study form 2" },
+        },
         { accessionId: "TESTID3", schema: `draft-${ObjectTypes.sample}` },
       ],
     },
@@ -41,5 +49,28 @@ describe("WizardStepper", () => {
       </Provider>
     )
     expect(screen.getAllByRole("button")).toHaveLength(4)
+  })
+
+  it("should have drafts listed for selected object type", async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={CSCtheme}>
+          <WizardDraftObjectPicker />
+        </ThemeProvider>
+      </Provider>
+    )
+    const formList = screen.getByRole("list", { name: ObjectTypes.study })
+    expect(formList).toBeInTheDocument()
+
+    const { getAllByRole } = within(formList)
+    const submittedForm = getAllByRole("listitem")
+    expect(submittedForm.length).toBe(2)
+
+    // Expect to render Study title and accessionId
+    expect(submittedForm[0]).toHaveTextContent("Study form 1")
+    expect(submittedForm[0]).toHaveTextContent("TESTID1")
+
+    expect(submittedForm[1]).toHaveTextContent("Study form 2")
+    expect(submittedForm[1]).toHaveTextContent("TESTID2")
   })
 })

--- a/src/__tests__/WizardSavedObjectsList.test.js
+++ b/src/__tests__/WizardSavedObjectsList.test.js
@@ -20,9 +20,21 @@ describe("WizardStepper", () => {
   })
 
   const submissions = [
-    { accessionId: "EDAG1", schema: ObjectTypes.sample, tags: { submissionType: ObjectSubmissionTypes.form } },
-    { accessionId: "EDAG2", schema: ObjectTypes.sample, tags: { submissionType: ObjectSubmissionTypes.xml } },
-    { accessionId: "EDAG3", schema: ObjectTypes.sample, tags: { submissionType: ObjectSubmissionTypes.xml } },
+    {
+      accessionId: "EDAG1",
+      schema: ObjectTypes.sample,
+      tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Sample 1" },
+    },
+    {
+      accessionId: "EDAG2",
+      schema: ObjectTypes.sample,
+      tags: { submissionType: ObjectSubmissionTypes.xml, fileName: "sample2.xml" },
+    },
+    {
+      accessionId: "EDAG3",
+      schema: ObjectTypes.sample,
+      tags: { submissionType: ObjectSubmissionTypes.xml, fileName: "sample3.xml" },
+    },
   ]
 
   beforeEach(() => {
@@ -41,6 +53,23 @@ describe("WizardStepper", () => {
     })
   })
 
+  it("should display correct submitted form' displayTitle", () => {
+    submissions.forEach(item => {
+      if (item.tags.submissionType === ObjectSubmissionTypes.form) {
+        expect(screen.getByText(item.tags.displayTitle)).toBeInTheDocument()
+        expect(screen.getByText(item.tags.displayTitle)).toHaveTextContent("Sample 1")
+      }
+    })
+  })
+
+  it("should display correct submitted xml' displayTitle", () => {
+    submissions.forEach(item => {
+      if (item.tags.submissionType === ObjectSubmissionTypes.xml) {
+        expect(screen.getByText(item.tags.fileName)).toBeInTheDocument()
+      }
+    })
+  })
+
   it("should have correct amount of submitted forms", () => {
     screen.getByText(/Submitted sample form/i)
     expect(screen.getByText(/Submitted sample form/i)).toBeInTheDocument()
@@ -53,7 +82,7 @@ describe("WizardStepper", () => {
     expect(submittedForms.length).toBe(1)
   })
 
-  it("should have correct amount of submitted forms", () => {
+  it("should have correct amount of submitted xml", () => {
     screen.getByText(/Submitted sample xml/i)
     expect(screen.getByText(/Submitted sample xml/i)).toBeInTheDocument()
 

--- a/src/__tests__/WizardShowSummaryStep.test.js
+++ b/src/__tests__/WizardShowSummaryStep.test.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import "@testing-library/jest-dom/extend-expect"
 import { ThemeProvider } from "@material-ui/core/styles"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { Provider } from "react-redux"
 import configureStore from "redux-mock-store"
 import { toMatchDiffSnapshot } from "snapshot-diff"
@@ -10,7 +10,7 @@ import { toMatchDiffSnapshot } from "snapshot-diff"
 import WizardShowSummaryStep from "../components/NewDraftWizard/WizardSteps/WizardShowSummaryStep"
 import CSCtheme from "../theme"
 
-import { ObjectTypes } from "constants/wizardObject"
+import { ObjectSubmissionTypes, ObjectTypes } from "constants/wizardObject"
 
 const mockStore = configureStore([])
 
@@ -36,8 +36,26 @@ describe("WizardShowSummaryStep", () => {
         description: "AWD",
         id: "FOL90524783",
         metadataObjects: [
-          { accessionId: "EDAG2584421211413887", schema: ObjectTypes.study },
-          { accessionId: "EDAG9880663174234413", schema: ObjectTypes.study },
+          {
+            accessionId: "EDAG2584421211413887",
+            schema: ObjectTypes.study,
+            tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Study form 1" },
+          },
+          {
+            accessionId: "EDAG9880663174234413",
+            schema: ObjectTypes.study,
+            tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Study form 2" },
+          },
+          {
+            accessionId: "EDAG9880663174452110",
+            schema: ObjectTypes.sample,
+            tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "Sample form 1" },
+          },
+          {
+            accessionId: "EDAG9880660036513985",
+            schema: ObjectTypes.dac,
+            tags: { submissionType: ObjectSubmissionTypes.form, displayTitle: "John Smith" },
+          },
         ],
         name: "AA",
         published: false,
@@ -50,11 +68,52 @@ describe("WizardShowSummaryStep", () => {
         </ThemeProvider>
       </Provider>
     )
+    render(wrapper)
   })
 
   it("should have uploaded objects listed", async () => {
-    render(wrapper)
-    const items = await screen.findAllByRole("button")
+    const items = await screen.findAllByRole("list")
     expect(items).toHaveLength(8) // Screen renders stepper back and next buttons and object actions
+  })
+
+  it("should renders Study list correctly", () => {
+    const formList = screen.getByRole("list", { name: ObjectTypes.study })
+    expect(formList).toBeInTheDocument()
+
+    const { getAllByRole } = within(formList)
+    const submittedForm = getAllByRole("listitem")
+    expect(submittedForm.length).toBe(2)
+
+    // Expect to render both Study titles and accessionIds
+    expect(submittedForm[0]).toHaveTextContent("Study form 1")
+    expect(submittedForm[0]).toHaveTextContent("EDAG2584421211413887")
+    expect(submittedForm[1]).toHaveTextContent("Study form 2")
+    expect(submittedForm[1]).toHaveTextContent("EDAG9880663174234413")
+  })
+
+  it("should renders Sample list correctly", () => {
+    const formList = screen.getByRole("list", { name: ObjectTypes.sample })
+    expect(formList).toBeInTheDocument()
+
+    const { getAllByRole } = within(formList)
+    const submittedForm = getAllByRole("listitem")
+    expect(submittedForm.length).toBe(1)
+
+    // Expect to render Sample title and accessionId
+    expect(submittedForm[0]).toHaveTextContent("Sample form 1")
+    expect(submittedForm[0]).toHaveTextContent("EDAG9880663174452110")
+  })
+
+  it("should renders DAC list correctly", () => {
+    const formList = screen.getByRole("list", { name: ObjectTypes.dac })
+    expect(formList).toBeInTheDocument()
+
+    const { getAllByRole } = within(formList)
+    const submittedForm = getAllByRole("listitem")
+    expect(submittedForm.length).toBe(1)
+
+    // Expect to render Sample title and accessionId
+    expect(submittedForm[0]).toHaveTextContent("Main Contact: John Smith")
+    expect(submittedForm[0]).toHaveTextContent("EDAG9880660036513985")
   })
 })

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
@@ -24,6 +24,8 @@ import { setCurrentObject } from "features/wizardCurrentObjectSlice"
 import { deleteObjectFromFolder } from "features/wizardSubmissionFolderSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import draftAPIService from "services/draftAPI"
+import type { ObjectInsideFolderWithTags } from "types"
+import { getItemPrimaryText } from "utils"
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -51,7 +53,9 @@ const WizardDraftObjectPicker = (): Node => {
   const dispatch = useDispatch()
   const objectType = useSelector(state => state.objectType)
   const folder = useSelector(state => state.submissionFolder)
-  const currentObjectTypeDrafts = folder.drafts.filter(draft => draft.schema === "draft-" + objectType)
+  const currentObjectTypeDrafts: Array<ObjectInsideFolderWithTags> = folder.drafts.filter(
+    draft => draft.schema === "draft-" + objectType
+  )
 
   const [connError, setConnError] = useState(false)
   const [responseError, setResponseError] = useState({})
@@ -104,7 +108,7 @@ const WizardDraftObjectPicker = (): Node => {
           {currentObjectTypeDrafts.map(submission => {
             return (
               <ListItem key={submission.accessionId} className={classes.objectListItem}>
-                <ListItemText primary={submission.accessionId} />
+                <ListItemText primary={getItemPrimaryText(submission)} secondary={submission.accessionId} />
                 <ListItemSecondaryAction>
                   <ButtonGroup aria-label="Draft actions button group">
                     <Button

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
@@ -111,7 +111,7 @@ const WizardDraftObjectPicker = (): Node => {
                 <ListItemText
                   primary={getItemPrimaryText(submission)}
                   secondary={submission.accessionId}
-                  data-testid={submission.schema}
+                  data-schema={submission.schema}
                 />
                 <ListItemSecondaryAction>
                   <ButtonGroup aria-label="Draft actions button group">

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
@@ -108,7 +108,11 @@ const WizardDraftObjectPicker = (): Node => {
           {currentObjectTypeDrafts.map(submission => {
             return (
               <ListItem key={submission.accessionId} className={classes.objectListItem}>
-                <ListItemText primary={getItemPrimaryText(submission)} secondary={submission.accessionId} />
+                <ListItemText
+                  primary={getItemPrimaryText(submission)}
+                  secondary={submission.accessionId}
+                  data-testid={submission.schema}
+                />
                 <ListItemSecondaryAction>
                   <ButtonGroup aria-label="Draft actions button group">
                     <Button

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftObjectPicker.js
@@ -104,7 +104,7 @@ const WizardDraftObjectPicker = (): Node => {
         className={classes.cardHeader}
       />
       {currentObjectTypeDrafts.length > 0 ? (
-        <List className={classes.objectList}>
+        <List className={classes.objectList} aria-label={objectType}>
           {currentObjectTypeDrafts.map(submission => {
             return (
               <ListItem key={submission.accessionId} className={classes.objectListItem}>

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
@@ -108,7 +108,7 @@ const WizardSavedObjectsList = ({ submissions }: WizardSavedObjectsListProps): R
                     className={classes.listItemText}
                     primary={getItemPrimaryText(item)}
                     secondary={item.accessionId}
-                    data-testid={item.schema}
+                    data-schema={item.schema}
                   />
                   <ListItemSecondaryAction>
                     <WizardSavedObjectActions

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
@@ -108,6 +108,7 @@ const WizardSavedObjectsList = ({ submissions }: WizardSavedObjectsListProps): R
                     className={classes.listItemText}
                     primary={getItemPrimaryText(item)}
                     secondary={item.accessionId}
+                    data-testid={item.schema}
                   />
                   <ListItemSecondaryAction>
                     <WizardSavedObjectActions

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectsList.js
@@ -14,6 +14,7 @@ import WizardSavedObjectActions from "./WizardSavedObjectActions"
 
 import { ObjectSubmissionTypes } from "constants/wizardObject"
 import type { ObjectInsideFolderWithTags } from "types"
+import { getItemPrimaryText } from "utils"
 
 const useStyles = makeStyles(theme => ({
   objectList: {
@@ -29,7 +30,7 @@ const useStyles = makeStyles(theme => ({
   listItemText: {
     display: "inline-block",
     maxWidth: "50%",
-    "& span": {
+    "& span, & p": {
       whiteSpace: "nowrap",
       overflow: "hidden",
       textOverflow: "ellipsis",
@@ -60,15 +61,17 @@ const WizardSavedObjectsList = ({ submissions }: WizardSavedObjectsListProps): R
 
   // filter submissionTypes that exist in current submissions & sort them according to alphabetical order
   const submissionTypes = submissions
-    .map(obj => obj.tags.submissionType)
+    .map(obj => (obj.tags.submissionType ? obj.tags.submissionType : ""))
     .filter((val, ind, arr) => arr.indexOf(val) === ind)
     .sort()
 
   // group submissions according to their submissionType
-  const groupedSubmissions = submissionTypes.map(submissionType => ({
-    submissionType,
-    submittedItems: submissions.filter(obj => obj.tags.submissionType === submissionType),
-  }))
+  const groupedSubmissions =
+    submissionTypes.length > 0 &&
+    submissionTypes.map(submissionType => ({
+      submissionType,
+      submittedItems: submissions.filter(obj => obj.tags.submissionType && obj.tags.submissionType === submissionType),
+    }))
 
   const displayObjectType = (objectType: string) => {
     return `${objectType.charAt(0).toUpperCase()}${objectType.slice(1)}`
@@ -90,31 +93,36 @@ const WizardSavedObjectsList = ({ submissions }: WizardSavedObjectsListProps): R
 
   return (
     <div className={classes.objectList}>
-      {groupedSubmissions.map(group => (
-        <Box pt={0} key={group.submissionType}>
-          <CardHeader
-            title={`Submitted ${displayObjectType(objectType)} ${displaySubmissionType(group)}`}
-            titleTypographyProps={{ variant: "inherit" }}
-            className={classes.cardHeader}
-          />
-          <List aria-label={group.submissionType}>
-            {group.submittedItems.map(item => (
-              <ListItem key={item.accessionId} className={classes.objectListItem}>
-                <ListItemText className={classes.listItemText} primary={item.accessionId} />
-                <ListItemSecondaryAction>
-                  <WizardSavedObjectActions
-                    submissions={submissions}
-                    objectType={objectType}
-                    objectId={item.accessionId}
-                    submissionType={group?.submissionType}
-                    tags={item.tags}
+      {groupedSubmissions &&
+        groupedSubmissions.map(group => (
+          <Box pt={0} key={group.submissionType}>
+            <CardHeader
+              title={`Submitted ${displayObjectType(objectType)} ${displaySubmissionType(group)}`}
+              titleTypographyProps={{ variant: "inherit" }}
+              className={classes.cardHeader}
+            />
+            <List aria-label={group.submissionType}>
+              {group.submittedItems.map(item => (
+                <ListItem key={item.accessionId} className={classes.objectListItem}>
+                  <ListItemText
+                    className={classes.listItemText}
+                    primary={getItemPrimaryText(item)}
+                    secondary={item.accessionId}
                   />
-                </ListItemSecondaryAction>
-              </ListItem>
-            ))}
-          </List>
-        </Box>
-      ))}
+                  <ListItemSecondaryAction>
+                    <WizardSavedObjectActions
+                      submissions={submissions}
+                      objectType={objectType}
+                      objectId={item.accessionId}
+                      submissionType={group?.submissionType}
+                      tags={item.tags}
+                    />
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        ))}
     </div>
   )
 }

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -220,13 +220,12 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
 
   const createNewForm = () => {
     resetTimer()
-    resetForm()
+    clearForm()
     setCurrentObjectId(null)
-    dispatch(resetDraftStatus())
     dispatch(resetCurrentObject())
   }
 
-  const resetForm = () => {
+  const clearForm = () => {
     methods.reset(formSchema)
     setCleanedValues({})
     dispatch(resetDraftStatus())
@@ -362,7 +361,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
         objectType,
         currentObject.status,
         folderId,
-        currentObject.cleanedValues || currentObject,
+        cleanedValues || currentObject.cleanedValues,
         dispatch
       )
       if (handleSave.ok && currentObject?.status !== ObjectStatus.submitted) {
@@ -400,7 +399,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
         currentObject={currentObject}
         refForm="hook-form"
         onClickNewForm={() => createNewForm()}
-        onClickClearForm={() => resetForm()}
+        onClickClearForm={() => clearForm()}
         onClickSaveDraft={() => saveDraft()}
         onClickSubmit={() => submitForm()}
       />

--- a/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
+++ b/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
@@ -4,7 +4,7 @@ import { WizardStatus } from "constants/wizardStatus"
 import { resetDraftStatus } from "features/draftStatusSlice"
 import { resetCurrentObject } from "features/wizardCurrentObjectSlice"
 import { updateStatus } from "features/wizardStatusMessageSlice"
-import { addObjectToDrafts } from "features/wizardSubmissionFolderSlice"
+import { addObjectToDrafts, modifyDraftObjectTags } from "features/wizardSubmissionFolderSlice"
 import draftAPIService from "services/draftAPI"
 import { getObjectDisplayTitle } from "utils"
 
@@ -16,10 +16,19 @@ const saveDraftHook = async (
   values: any,
   dispatch: function
 ): any => {
+  const draftDisplayTitle = getObjectDisplayTitle(objectType, values)
   if (accessionId && objectStatus === ObjectStatus.draft) {
     const response = await draftAPIService.patchFromJSON(objectType, accessionId, values)
     if (response.ok) {
       dispatch(resetDraftStatus())
+      dispatch(
+        modifyDraftObjectTags({
+          accessionId,
+          tags: {
+            displayTitle: draftDisplayTitle,
+          },
+        })
+      )
       dispatch(
         updateStatus({
           successStatus: WizardStatus.success,
@@ -43,7 +52,6 @@ const saveDraftHook = async (
   } else {
     const response = await draftAPIService.createFromJSON(objectType, values)
     if (response.ok) {
-      const draftDisplayTitle = getObjectDisplayTitle(objectType, values)
       dispatch(
         updateStatus({
           successStatus: WizardStatus.success,

--- a/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
+++ b/src/components/NewDraftWizard/WizardHooks/WizardSaveDraftHook.js
@@ -6,6 +6,7 @@ import { resetCurrentObject } from "features/wizardCurrentObjectSlice"
 import { updateStatus } from "features/wizardStatusMessageSlice"
 import { addObjectToDrafts } from "features/wizardSubmissionFolderSlice"
 import draftAPIService from "services/draftAPI"
+import { getObjectDisplayTitle } from "utils"
 
 const saveDraftHook = async (
   accessionId?: string,
@@ -42,6 +43,7 @@ const saveDraftHook = async (
   } else {
     const response = await draftAPIService.createFromJSON(objectType, values)
     if (response.ok) {
+      const draftDisplayTitle = getObjectDisplayTitle(objectType, values)
       dispatch(
         updateStatus({
           successStatus: WizardStatus.success,
@@ -54,6 +56,7 @@ const saveDraftHook = async (
         addObjectToDrafts(folderId, {
           accessionId: response.data.accessionId,
           schema: "draft-" + objectType,
+          tags: { displayTitle: draftDisplayTitle },
         })
       )
       dispatch(resetCurrentObject())

--- a/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
@@ -14,6 +14,7 @@ import WizardSavedObjectActions from "../WizardComponents/WizardSavedObjectActio
 import WizardStepper from "../WizardComponents/WizardStepper"
 
 import type { ObjectInsideFolderWithTags } from "types"
+import { getItemPrimaryText } from "utils"
 
 const useStyles = makeStyles(theme => ({
   summary: {
@@ -81,13 +82,13 @@ const WizardShowSummaryStep = (): React$Element<any> => {
               <div>
                 {group[schema].map(item => (
                   <ListItem button key={item.accessionId} dense className={classes.objectListItems}>
-                    <ListItemText primary={item.accessionId} />
+                    <ListItemText primary={getItemPrimaryText(item)} secondary={item.accessionId} />
                     <ListItemSecondaryAction>
                       <WizardSavedObjectActions
                         submissions={metadataObjects}
                         objectType={schema}
                         objectId={item.accessionId}
-                        submissionType={item.tags?.submissionType}
+                        submissionType={item.tags?.submissionType ? item.tags.submissionType : ""}
                         tags={item.tags}
                         summary={true}
                       />

--- a/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
@@ -85,7 +85,7 @@ const WizardShowSummaryStep = (): React$Element<any> => {
                     <ListItemText
                       primary={getItemPrimaryText(item)}
                       secondary={item.accessionId}
-                      data-testid={item.schema}
+                      data-schema={item.schema}
                     />
                     <ListItemSecondaryAction>
                       <WizardSavedObjectActions

--- a/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardShowSummaryStep.js
@@ -82,7 +82,11 @@ const WizardShowSummaryStep = (): React$Element<any> => {
               <div>
                 {group[schema].map(item => (
                   <ListItem button key={item.accessionId} dense className={classes.objectListItems}>
-                    <ListItemText primary={getItemPrimaryText(item)} secondary={item.accessionId} />
+                    <ListItemText
+                      primary={getItemPrimaryText(item)}
+                      secondary={item.accessionId}
+                      data-testid={item.schema}
+                    />
                     <ListItemSecondaryAction>
                       <WizardSavedObjectActions
                         submissions={metadataObjects}

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -9,7 +9,7 @@ import objectAPIService from "../services/objectAPI"
 import { ObjectStatus } from "constants/wizardObject"
 import folderAPIService from "services/folderAPI"
 import publishAPIService from "services/publishAPI"
-import type { FolderDetails, FolderDetailsWithId, FolderDataFromForm, ObjectInsideFolder } from "types"
+import type { FolderDetails, FolderDetailsWithId, FolderDataFromForm, ObjectInsideFolderWithTags } from "types"
 
 const initialState: null | FolderDetailsWithId = null
 
@@ -102,7 +102,7 @@ export const updateNewDraftFolder = (
 
 export const addObjectToFolder = (
   folderID: string,
-  objectDetails: ObjectInsideFolder
+  objectDetails: ObjectInsideFolderWithTags
 ): ((dispatch: (any) => void) => Promise<any>) => async (dispatch: any => void) => {
   const changes = [{ op: "add", path: "/metadataObjects/-", value: objectDetails }]
   const response = await folderAPIService.patchFolderById(folderID, changes)
@@ -136,7 +136,7 @@ export const replaceObjectInFolder = (
 
 export const addObjectToDrafts = (
   folderID: string,
-  objectDetails: ObjectInsideFolder
+  objectDetails: ObjectInsideFolderWithTags
 ): ((dispatch: (any) => void) => Promise<any>) => async (dispatch: any => void) => {
   const changes = [{ op: "add", path: "/drafts/-", value: objectDetails }]
   const folderResponse = await folderAPIService.patchFolderById(folderID, changes)

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -37,9 +37,13 @@ const wizardSubmissionFolderSlice: any = createSlice({
     modifyObjectTags: (state, action) => {
       state.metadataObjects.find(item => item.accessionId === action.payload.accessionId).tags = action.payload.tags
     },
+    modifyDraftObjectTags: (state, action) => {
+      state.drafts.find(item => item.accessionId === action.payload.accessionId).tags = action.payload.tags
+    },
     resetFolder: () => initialState,
   },
 })
+
 export const {
   setFolder,
   addObject,
@@ -47,6 +51,7 @@ export const {
   deleteObject,
   deleteDraftObject,
   modifyObjectTags,
+  modifyDraftObjectTags,
   resetFolder,
 } = wizardSubmissionFolderSlice.actions
 export default wizardSubmissionFolderSlice.reducer

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -21,8 +21,9 @@ export type ObjectInsideFolder = {
 }
 
 export type ObjectTags = {
-  submissionType: string,
+  submissionType?: string,
   fileName?: string,
+  displayTitle?: string,
 }
 
 export type ObjectInsideFolderWithTags = ObjectInsideFolder & { tags: ObjectTags }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,11 +6,11 @@ import type { ObjectInsideFolderWithTags } from "types"
 export const getObjectDisplayTitle = (objectType: string, cleanedValues: any): string => {
   switch (objectType) {
     case ObjectTypes.study:
-      return cleanedValues.descriptor.studyTitle
+      return cleanedValues.descriptor?.studyTitle || ""
     case ObjectTypes.dac:
-      return cleanedValues.contacts.find(contact => contact.mainContact).name
+      return cleanedValues.contacts?.find(contact => contact.mainContact).name || ""
     default:
-      return cleanedValues.title
+      return cleanedValues.title || ""
   }
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,30 @@
+//@flow
+
+import { ObjectTypes } from "constants/wizardObject"
+import type { ObjectInsideFolderWithTags } from "types"
+
+export const getObjectDisplayTitle = (objectType: string, cleanedValues: any): string => {
+  switch (objectType) {
+    case ObjectTypes.study:
+      return cleanedValues.descriptor.studyTitle
+    case ObjectTypes.dac:
+      return cleanedValues.contacts.find(contact => contact.mainContact).name
+    default:
+      return cleanedValues.title
+  }
+}
+
+export const getItemPrimaryText = (item: ObjectInsideFolderWithTags): string => {
+  if (item.tags?.displayTitle) {
+    switch (item.schema) {
+      case ObjectTypes.dac:
+      case `draft-${ObjectTypes.dac}`:
+        return `Main Contact: ${item.tags.displayTitle}`
+      default:
+        return item.tags.displayTitle
+    }
+  } else if (item.tags?.fileName) {
+    return item.tags.fileName
+  }
+  return ""
+}


### PR DESCRIPTION
### Description

- **submitted** and **draft** objects are displayed by `title` and `accessionId`, instead of showing only their `accessionId`

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/174

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

- Assign `form's title` or `xml's fileName` as value of `displayTitle` in `tags: {  displayTitle: " "}` when `create` object or `patch` folder
- Include `displayTitle` and `accessionId` for `ListItem` in components `WizardSavedObjectsList`, `WizardShowSummaryStep`, and `WizardDraftObjectPicker`
- Create a new file `utils/index.js` to contain reusable functions
- Fix logics for functions `saveDraft()` and `submit()` with `tags` 
- Update Unit tests for changes in related components

### Testing

- [x] Unit Tests
- [x] Integration Tests



