### PR TITLE
move ajv to v8+ dataPath -> instancePath

### DIFF
--- a/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
@@ -9,8 +9,8 @@ import JSONSchemaParser from "./WizardJSONSchemaParser"
  */
 const parseErrorSchema = (validationError, validateAllFieldCriteria) =>
   Array.isArray(validationError.errors)
-    ? validationError.errors.reduce((previous, { dataPath, message = "", params, propertyName = "" }) => {
-        const path = dataPath.replace(/\//g, ".").replace(/^\./, "") || propertyName
+    ? validationError.errors.reduce((previous, { instancePath, message = "", params, propertyName = "" }) => {
+        const path = instancePath.replace(/\//g, ".").replace(/^\./, "") || propertyName
         return {
           ...previous,
           ...(path


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Switching to v8 introduced some issues: https://github.com/ajv-validator/ajv/blob/master/docs/v6-to-v8-migration.md#new-features

```
JSON Schema validation errors changes:

    dataPath property replaced with instancePath
    "should" replaced with "must" in the messages
    property name is removed from "propertyName" keyword error 
      message (it is still available in error.params.propertyName).

```
### Related issues

<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
`dataPath` property replaced with `instancePath`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions

<!-- Shout outs to your friends that you made this happen or need help. -->
I am not sure about `propertyName` but does not seem there is any error, or we are not using the `name` and we are using the `error message` from `propertyName`.