### PR TITLE
Test blur on form field

### DIFF
--- a/src/__tests__/WizardFillObjectDetailsForm.test.js
+++ b/src/__tests__/WizardFillObjectDetailsForm.test.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import "@testing-library/jest-dom/extend-expect"
 import { ThemeProvider } from "@material-ui/core/styles"
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { Provider } from "react-redux"
 import configureStore from "redux-mock-store"
 
@@ -27,6 +27,11 @@ describe("WizardFillObjectDetailsForm", () => {
           studyTitle: {
             title: "Study Title",
             description: "Title of the study as would be used in a publication.",
+            type: "string",
+          },
+          studyTestField: {
+            title: "Study Test Field",
+            description: "Study test field description.",
             type: "string",
           },
         },
@@ -57,6 +62,22 @@ describe("WizardFillObjectDetailsForm", () => {
     )
     await waitFor(() => screen.getByText("Study Description"))
     expect(screen.getByText("Study Description")).toBeDefined()
+  })
+
+  it("should validate without errors on blur", async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={CSCtheme}>
+          <WizardFillObjectDetailsForm />
+        </ThemeProvider>
+      </Provider>
+    )
+    await waitFor(() => {
+      const input = screen.getByTestId("descriptor.studyTitle")
+      fireEvent.change(input, { target: { value: "Title" } })
+      fireEvent.blur(input)
+      expect(input).toBeVisible()
+    })
   })
 
   // Note: If this test runs before form creation, form creation fails because getItem spy messes sessionStorage init somehow

--- a/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
@@ -9,8 +9,8 @@ import JSONSchemaParser from "./WizardJSONSchemaParser"
  */
 const parseErrorSchema = (validationError, validateAllFieldCriteria) =>
   Array.isArray(validationError.errors)
-    ? validationError.errors.reduce((previous, { dataPath, message = "", params, propertyName = "" }) => {
-        const path = dataPath.replace(/\//g, ".").replace(/^\./, "") || propertyName
+    ? validationError.errors.reduce((previous, { instancePath, message = "", params, propertyName = "" }) => {
+        const path = instancePath.replace(/\//g, ".").replace(/^\./, "") || propertyName
         return {
           ...previous,
           ...(path
@@ -44,7 +44,7 @@ export const WizardAjvResolver = validationSchema => {
     throw new Error("Undefined schema, not able to validate")
   }
   const ajv = new Ajv({ allErrors: true, coerceTypes: true, strict: false })
-  addFormats(ajv,  {mode: "fast", formats: ["email", "uri"], keywords: true})
+  addFormats(ajv, { mode: "fast", formats: ["email", "uri"], keywords: true })
   return async values => {
     const validate = ajv.compile(validationSchema)
     const cleanedValues = JSONSchemaParser.cleanUpFormValues(values)

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -247,8 +247,10 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   const handleChange = () => {
     const clone = cloneDeep(currentObject)
     const values = JSONSchemaParser.cleanUpFormValues(methods.getValues())
+
     setCleanedValues(values)
-    if (checkFormCleanedValuesEmpty(values)) {
+
+    if (clone && checkFormCleanedValuesEmpty(values)) {
       Object.keys(values).forEach(item => (clone[item] = values[item]))
 
       !currentObject.accessionId && currentObjectId

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -337,7 +337,9 @@ const FormTextField = ({
       return (
         <ValidationTextField
           name={name}
+          inputProps={{ "data-testid": name }}
           label={label}
+          role="textbox"
           inputRef={register}
           defaultValue={getDefaultValue(nestedField, name)}
           error={!!error}


### PR DESCRIPTION
### Description

AJV package update revealed untested piece on form field validation. 
Validation triggers on blur and this event should be tested.

### Related issues

Closes #221 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Test blur event in `WizardFillObjectDetailsForm.test.js`
- Check that data exists in forms `handleChange` method
- Added test id to get the input from Material Textfield

### Testing

- [x] Integration Tests
