### PR TITLE
Tests for error pages

### DIFF
--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -25,7 +25,7 @@ describe("catch error codes and display corresponding error page", function () {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
     cy.visit(baseUrl + "unknownroute")
-    cy.contains(".MuiAlert-message", "404 Not Found")
+    cy.get(".MuiAlert-message", { timeout: 30000 }).contains("404 Not Found")
   })
 
   it("should redirect to 500 page if response status code is 500 ", () => {

--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -22,10 +22,8 @@ describe("catch error codes and display corresponding error page", function () {
   })
 
   it("should redirect to 404 page on unknown route", () => {
-    cy.visit(baseUrl)
-    cy.get('[alt="CSC Login"]').click()
     cy.visit(baseUrl + "unknownroute")
-    cy.get(".MuiAlert-message", { timeout: 30000 }).contains("404 Not Found")
+    cy.contains(".MuiAlert-message", "404 Not Found")
   })
 
   it("should redirect to 500 page if response status code is 500 ", () => {

--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -1,0 +1,45 @@
+describe("catch error codes and display corresponding error page", function () {
+  const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
+
+  it("should redirect to 401 page if no granted access", () => {
+    cy.visit(baseUrl + "home")
+    cy.contains(".MuiAlert-message", "401 Authorization Error")
+  })
+
+  it("should redirect to 403 page if response status code is 403 ", () => {
+    cy.intercept(
+      {
+        method: "GET",
+        url: "/folders",
+      },
+      {
+        statusCode: 403,
+      }
+    )
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.contains(".MuiAlert-message", "403 Forbidden Error")
+  })
+
+  it("should redirect to 404 page on unknown route", () => {
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.visit(baseUrl + "unknownroute")
+    cy.contains(".MuiAlert-message", "404 Not Found")
+  })
+
+  it("should redirect to 500 page if response status code is 500 ", () => {
+    cy.intercept(
+      {
+        method: "GET",
+        url: "/folders",
+      },
+      {
+        statusCode: 500,
+      }
+    )
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.contains(".MuiAlert-message", "500 Internal Server Error")
+  })
+})

--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -22,7 +22,9 @@ describe("catch error codes and display corresponding error page", function () {
   })
 
   it("should redirect to 404 page on unknown route", () => {
-    cy.visit(baseUrl + "unknownroute")
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.visit(baseUrl + "home/unknownroute")
     cy.contains(".MuiAlert-message", "404 Not Found")
   })
 


### PR DESCRIPTION
### Description

Test that error situations trigger corresponding error pages.

### Related issues

Closes #120 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Intercept 403 and 500 errors
- Check that error pages render

### Testing

- [x] Integration Tests

