### PR TITLE
Feature/draft selections

### DIFF
--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -35,7 +35,7 @@ describe("draft selections and templates", function () {
 
     // Create and Save another draft - Sample draft
     cy.get("div[role=button]").contains("Sample").click()
-    cy.get("div[role=button]")
+    cy.get("div[role=button]", { timeout: 10000 })
       .contains("Fill Form")
       .should("be.visible")
       .then($btn => $btn.click())

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -1,0 +1,66 @@
+describe("draft selections and templates", function () {
+  const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
+
+  it("should show the list of drafts before folder is published", () => {
+    cy.visit(baseUrl)
+    cy.get('[alt="CSC Login"]').click()
+    cy.visit(baseUrl + "newdraft")
+
+    // Navigate to folder creation
+    cy.get("button[type=button]").contains("New folder").click()
+
+    // Add folder name & description, navigate to submissions
+    cy.get("input[name='name']").type("Test name")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Fill a Study form
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Study test title")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Study test title")
+    cy.get("select[name='descriptor.studyType']").select("Metagenomics")
+
+    // Submit Study form
+    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Create another Study draft form
+    cy.get("button").contains("New form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Study draft title")
+
+    // Save a draft
+    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Create and Save another draft - Sample draft
+    cy.get("div[role=button]").contains("Sample").click()
+    cy.get("div[role=button]")
+      .contains("Fill Form")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    cy.get("input[name='title']").type("Sample draft title ")
+    cy.get("input[name='sampleName.taxonId']").type(123)
+    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Navigate to summary
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Navigate to publish button at the bottom
+    cy.get("button[type=button]").contains("Publish").click()
+
+    // Select drafts inside the dialog
+    cy.get("form").within(() => {
+      cy.get("input[type='checkbox']").first().check()
+      cy.get("input[type='checkbox']").last().check()
+
+      // Publish folder
+      cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
+    })
+
+    // Navigate back to home page
+    cy.get("div", { timeout: 10000 }).contains("Logged in as:")
+  })
+})

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -1,7 +1,7 @@
 describe("draft selections and templates", function () {
   const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
 
-  it("should show the list of drafts before folder is published", () => {
+  beforeEach(() => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
     cy.visit(baseUrl + "newdraft")
@@ -13,7 +13,9 @@ describe("draft selections and templates", function () {
     cy.get("input[name='name']").type("Test name")
     cy.get("textarea[name='description']").type("Test description")
     cy.get("button[type=button]").contains("Next").click()
+  })
 
+  it("should show the list of drafts before folder is published", () => {
     // Fill a Study form
     cy.get("div[role=button]").contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()
@@ -62,5 +64,51 @@ describe("draft selections and templates", function () {
 
     // Navigate back to home page
     cy.get("div", { timeout: 10000 }).contains("Logged in as:")
+  })
+
+  it("should open the correct draft when clicking View button", () => {
+    // Fill a Study form
+    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Study test title")
+    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Study test title")
+    cy.get("select[name='descriptor.studyType']").select("Metagenomics")
+
+    // Submit Study form
+    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Create another Study draft form
+    cy.get("button").contains("New form").click()
+    cy.get("input[name='descriptor.studyTitle']").type("Study draft title")
+
+    // Save a draft
+    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Create and Save another draft - Sample draft
+    cy.get("div[role=button]").contains("Sample").click()
+    cy.get("div[role=button]", { timeout: 10000 })
+      .contains("Fill Form")
+      .should("be.visible")
+      .then($btn => $btn.click())
+
+    cy.get("input[name='title']").type("Sample draft title")
+    cy.get("input[name='sampleName.taxonId']").type(123)
+    cy.get("button[type=button]").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Navigate to summary
+    cy.get("button[type=button]").contains("Next").click()
+
+    // Navigate to publish button at the bottom
+    cy.get("button[type=button]").contains("Publish").click()
+
+    // Select drafts inside the dialog
+    cy.get("form").within(() => {
+      cy.get("button[aria-label='View draft']").last().click()
+    })
+    cy.get("h1", { timeout: 10000 }).contains("Sample").should("be.visible")
+    cy.get("input[name='title']").should("have.value", "Sample draft title")
   })
 })

--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -2,7 +2,8 @@ describe("catch error codes and display corresponding error page", function () {
   const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
 
   it("should redirect to 401 page if no granted access", () => {
-    cy.visit(baseUrl + "home")
+    cy.contains("Log out").click()
+    cy.visit(baseUrl + "folders")
     cy.contains(".MuiAlert-message", "401 Authorization Error")
   })
 

--- a/cypress/integration/errorPages.spec.js
+++ b/cypress/integration/errorPages.spec.js
@@ -2,7 +2,6 @@ describe("catch error codes and display corresponding error page", function () {
   const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
 
   it("should redirect to 401 page if no granted access", () => {
-    cy.contains("Log out").click()
     cy.visit(baseUrl + "folders")
     cy.contains(".MuiAlert-message", "401 Authorization Error")
   })

--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -95,7 +95,6 @@ const CancelFormDialog = ({
   }
 
   let [dialogTitle, dialogContent] = ["", ""]
-  // let draftSelections = null
   let dialogActions
   const formContent = "If you save form as a draft, you can continue filling it later."
   const xmlContent = "If you save xml as a draft, you can upload it later."

--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -223,12 +223,7 @@ const CancelFormDialog = ({
           dialogTitle = "Publishing objects"
           dialogContent =
             "Objects in this folder will be published. Please choose the drafts you would like to save, unsaved drafts will be removed from this folder."
-
-          dialogActions = (
-            <DialogActions style={{ justifyContent: "center" }}>
-              <WizardDraftSelections onHandleDialog={handleDialog} />
-            </DialogActions>
-          )
+          dialogActions = <WizardDraftSelections onHandleDialog={handleDialog} />
           break
         }
         default: {
@@ -289,7 +284,6 @@ const CancelFormDialog = ({
       <DialogTitle id="alert-dialog-title">{dialogTitle}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">{dialogContent}</DialogContentText>
-        {/* {draftSelections} */}
       </DialogContent>
       {error && <ErrorMessage message={errorMessage} />}
       {dialogActions}

--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -226,7 +226,7 @@ const CancelFormDialog = ({
 
           dialogActions = (
             <DialogActions style={{ justifyContent: "center" }}>
-              <WizardDraftSelections onHandleDialog={formData => handleDialog(true, formData)} onPublish={() => {}} />
+              <WizardDraftSelections onHandleDialog={handleDialog} />
             </DialogActions>
           )
           break

--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -12,6 +12,8 @@ import { useDispatch, useSelector } from "react-redux"
 
 import saveDraftHook from "../WizardHooks/WizardSaveDraftHook"
 
+import WizardDraftSelections from "./WizardDraftSelections"
+
 import { ObjectSubmissionTypes, ObjectStatus } from "constants/wizardObject"
 import { WizardStatus } from "constants/wizardStatus"
 import { resetDraftStatus } from "features/draftStatusSlice"
@@ -19,6 +21,7 @@ import { setAlert, resetAlert } from "features/wizardAlertSlice"
 import { resetCurrentObject } from "features/wizardCurrentObjectSlice"
 import { updateStatus } from "features/wizardStatusMessageSlice"
 import objectAPIService from "services/objectAPI"
+import type { ObjectInsideFolderWithTags } from "types"
 
 // Simple template for error messages
 const ErrorMessage = message => {
@@ -34,7 +37,7 @@ const CancelFormDialog = ({
   parentLocation,
   currentSubmissionType,
 }: {
-  handleDialog: boolean => void,
+  handleDialog: (boolean, formData?: Array<ObjectInsideFolderWithTags>) => void,
   alertType: string,
   parentLocation: string,
   currentSubmissionType: string,
@@ -92,6 +95,7 @@ const CancelFormDialog = ({
   }
 
   let [dialogTitle, dialogContent] = ["", ""]
+  // let draftSelections = null
   let dialogActions
   const formContent = "If you save form as a draft, you can continue filling it later."
   const xmlContent = "If you save xml as a draft, you can upload it later."
@@ -218,17 +222,11 @@ const CancelFormDialog = ({
         case "publish": {
           dialogTitle = "Publishing objects"
           dialogContent =
-            "Objects in this folder will be published. Publishing will remove saved drafts from this folder."
+            "Objects in this folder will be published. Please choose the drafts you would like to save, unsaved drafts will be removed from this folder."
+
           dialogActions = (
             <DialogActions style={{ justifyContent: "center" }}>
-              <Button
-                variant="contained"
-                aria-label="Publish folder contents and move to frontpage"
-                onClick={() => handleDialog(true)}
-                color="primary"
-              >
-                Publish
-              </Button>
+              <WizardDraftSelections onHandleDialog={formData => handleDialog(true, formData)} onPublish={() => {}} />
             </DialogActions>
           )
           break
@@ -291,6 +289,7 @@ const CancelFormDialog = ({
       <DialogTitle id="alert-dialog-title">{dialogTitle}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">{dialogContent}</DialogContentText>
+        {/* {draftSelections} */}
       </DialogContent>
       {error && <ErrorMessage message={errorMessage} />}
       {dialogActions}
@@ -306,7 +305,7 @@ const WizardAlert = ({
   parentLocation,
   alertType,
 }: {
-  onAlert: boolean => void,
+  onAlert: (boolean, formData?: Array<ObjectInsideFolderWithTags>) => void,
   parentLocation: string,
   alertType: string,
 }): React$Element<any> => {
@@ -318,9 +317,9 @@ const WizardAlert = ({
     dispatch(setAlert())
   }, [])
 
-  const handleDialog = (action: boolean) => {
+  const handleDialog = (action: boolean, formData?: Array<ObjectInsideFolderWithTags>) => {
     dispatch(resetAlert())
-    onAlert(action)
+    onAlert(action, formData)
   }
 
   return (

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -16,6 +16,7 @@ import { useHistory } from "react-router-dom"
 import { ObjectSubmissionTypes, ObjectStatus } from "constants/wizardObject"
 import { WizardStatus } from "constants/wizardStatus"
 import { setCurrentObject } from "features/wizardCurrentObjectSlice"
+import { setObjectType } from "features/wizardObjectTypeSlice"
 import { updateStatus } from "features/wizardStatusMessageSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import draftAPIService from "services/draftAPI"
@@ -122,6 +123,7 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
     if (response.ok) {
       dispatch(setCurrentObject({ ...response.data, status: ObjectStatus.draft }))
       dispatch(setSubmissionType(ObjectSubmissionTypes.form))
+      dispatch(setObjectType(objectType))
       props.onHandleDialog(false)
       history.push({ pathname: "/newdraft", search: "step=1" })
     } else {

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -26,9 +26,11 @@ const useStyles = makeStyles(theme => ({
   formComponent: {
     margin: theme.spacing(2),
     padding: 0,
-    overflow: "scroll",
+    overflowY: "auto",
   },
-  formControl: { marginBottom: theme.spacing(1) },
+  formControl: {
+    marginBottom: theme.spacing(1),
+  },
   formLabel: {
     fontWeight: "bold",
     color: theme.palette.grey[900],
@@ -42,17 +44,28 @@ const useStyles = makeStyles(theme => ({
     borderBottom: `solid 1px ${theme.palette.secondary.main}`,
   },
   label: {
-    display: "flex",
-    flexDirection: "row",
+    margin: 0,
+    padding: 0,
+  },
+  listItemText: {
+    float: "left",
+    maxWidth: "50%",
+    "& span, & p": {
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      maxWidth: "50vw",
+    },
   },
   viewButton: {
     color: theme.palette.button.edit,
     margin: theme.spacing(1.5, 0),
+    float: "right",
   },
   buttonGroup: {
     marginTop: theme.spacing(2),
     display: "flex",
-    flexDirection: "row-re",
+    flexDirection: "row",
     justifyContent: "space-between",
     position: "sticky",
     zIndex: 1,
@@ -148,6 +161,7 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
                         label={
                           <div className={classes.label}>
                             <ListItemText
+                              className={classes.listItemText}
                               primary={getItemPrimaryText(item)}
                               secondary={item.accessionId}
                               data-schema={item.schema}

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -24,8 +24,9 @@ import { getItemPrimaryText } from "utils"
 
 const useStyles = makeStyles(theme => ({
   formComponent: {
-    margin: theme.spacing(2, 0),
+    margin: theme.spacing(2),
     padding: 0,
+    overflow: "scroll",
   },
   formControl: { marginBottom: theme.spacing(1) },
   formLabel: {
@@ -33,11 +34,12 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.grey[900],
     padding: theme.spacing(1),
     borderBottom: `3px solid ${theme.palette.primary.main}`,
+    textTransform: "capitalize",
   },
   formControlLabel: {
-    margin: 0,
-    borderBottom: `solid 1px ${theme.palette.secondary.main}`,
     padding: 0,
+    margin: theme.spacing(1, 0),
+    borderBottom: `solid 1px ${theme.palette.secondary.main}`,
   },
   label: {
     display: "flex",
@@ -47,9 +49,15 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.button.edit,
     margin: theme.spacing(1.5, 0),
   },
-  publishButton: {
+  buttonGroup: {
     marginTop: theme.spacing(2),
-    float: "right",
+    display: "flex",
+    flexDirection: "row-re",
+    justifyContent: "space-between",
+    position: "sticky",
+    zIndex: 1,
+    backgroundColor: theme.palette.background.default,
+    bottom: 0,
   },
 }))
 
@@ -88,12 +96,10 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
   const onSubmit = data => {
     const checkedBoxValues = Object.values(data).filter(data => data)
 
-    if (checkedBoxValues.length > 0) {
-      const checkedDrafts: Array<ObjectInsideFolderWithTags> = checkedBoxValues.map(item =>
-        folder.drafts.find(draft => draft.accessionId === item)
-      )
-      props.onHandleDialog(true, checkedDrafts)
-    }
+    const selectedDrafts: Array<ObjectInsideFolderWithTags> = checkedBoxValues.map(item =>
+      folder.drafts.find(draft => draft.accessionId === item)
+    )
+    props.onHandleDialog(true, selectedDrafts)
   }
 
   const handleViewButton = async (draftSchema: string, draftId: string) => {
@@ -122,7 +128,7 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
         {draftObjects.map(draft => {
           const schema = Object.keys(draft)[0]
           return (
-            <ConnectForm key={schema} className={classes.connectionForm}>
+            <ConnectForm key={schema}>
               {({ register }) => (
                 <FormControl className={classes.formControl} fullWidth>
                   <FormLabel className={classes.formLabel}>{schema}</FormLabel>
@@ -165,15 +171,24 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
             </ConnectForm>
           )
         })}
-        <Button
-          className={classes.publishButton}
-          variant="contained"
-          aria-label="Publish folder contents and move to frontpage"
-          color="primary"
-          type="submit"
-        >
-          Publish
-        </Button>
+        <div className={classes.buttonGroup}>
+          <Button
+            variant="contained"
+            aria-label="Cancel publishing folder contents"
+            color="secondary"
+            onClick={() => props.onHandleDialog(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            aria-label="Publish folder contents and move to frontpage"
+            color="primary"
+            type="submit"
+          >
+            Publish
+          </Button>
+        </div>
       </form>
     </FormProvider>
   )

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -1,0 +1,153 @@
+//@flow
+import React from "react"
+
+import Button from "@material-ui/core/Button"
+import Checkbox from "@material-ui/core/Checkbox"
+import FormControl from "@material-ui/core/FormControl"
+import MuiFormControlLabel from "@material-ui/core/FormControlLabel"
+import FormGroup from "@material-ui/core/FormGroup"
+import FormLabel from "@material-ui/core/FormLabel"
+import ListItemText from "@material-ui/core/ListItemText"
+import { makeStyles, withStyles } from "@material-ui/core/styles"
+import { useForm, FormProvider, useFormContext } from "react-hook-form"
+import { useSelector } from "react-redux"
+
+import type { ObjectInsideFolderWithTags } from "types"
+import { getItemPrimaryText } from "utils"
+
+const useStyles = makeStyles(theme => ({
+  formComponent: {
+    margin: theme.spacing(2, 0),
+    padding: 0,
+  },
+  formControl: { marginBottom: theme.spacing(1) },
+  formLabel: {
+    fontWeight: "bold",
+    color: theme.palette.grey[900],
+    padding: theme.spacing(1),
+    borderBottom: `3px solid ${theme.palette.primary.main}`,
+  },
+  formControlLabel: {
+    margin: 0,
+    borderBottom: `solid 1px ${theme.palette.secondary.main}`,
+    padding: 0,
+  },
+  label: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  viewButton: {
+    color: theme.palette.button.edit,
+    margin: theme.spacing(1.5, 0),
+  },
+  publishButton: {
+    marginTop: theme.spacing(2),
+    float: "right",
+  },
+}))
+
+const FormControlLabel = withStyles({
+  label: {
+    width: "100%",
+  },
+})(MuiFormControlLabel)
+
+const ConnectForm = ({ children }) => {
+  const methods = useFormContext()
+
+  return children({ ...methods })
+}
+
+type WizardDraftSelectionsProps = {
+  onHandleDialog: (data: Array<ObjectInsideFolderWithTags>) => void,
+}
+
+const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element<any> => {
+  const classes = useStyles()
+  const folder = useSelector(state => state.submissionFolder)
+  const objectsArray = useSelector(state => state.objectsArray)
+
+  // draftObjects contains an array of objects and each has a schema and the related draft(s) array if there is any
+  const draftObjects = objectsArray.flatMap((schema: string) => {
+    const draftSchema = `draft-${schema}`
+    const draftArray = folder.drafts.filter(draft => draft.schema.toLowerCase() === draftSchema.toLowerCase())
+    return draftArray.length > 0 ? [{ [`draft-${schema}`]: draftArray }] : []
+  })
+
+  const methods = useForm()
+
+  const onSubmit = data => {
+    const checkedBoxValues = Object.values(data).filter(data => data)
+
+    if (checkedBoxValues.length > 0) {
+      const checkedDrafts: Array<ObjectInsideFolderWithTags> = checkedBoxValues.map(item =>
+        folder.drafts.find(draft => draft.accessionId === item)
+      )
+      props.onHandleDialog(checkedDrafts)
+    }
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)} className={classes.formComponent}>
+        {draftObjects.map(draft => {
+          const schema = Object.keys(draft)[0]
+          return (
+            <ConnectForm key={schema} className={classes.connectionForm}>
+              {({ register }) => (
+                <FormControl className={classes.formControl} fullWidth>
+                  <FormLabel className={classes.formLabel}>{schema}</FormLabel>
+                  <FormGroup>
+                    {draft[schema].map(item => (
+                      <FormControlLabel
+                        key={item.accessionId}
+                        className={classes.formControlLabel}
+                        control={
+                          <Checkbox
+                            color="primary"
+                            name={item.accessionId}
+                            value={item.accessionId}
+                            inputRef={register}
+                          />
+                        }
+                        label={
+                          <div className={classes.label}>
+                            <ListItemText
+                              primary={getItemPrimaryText(item)}
+                              secondary={item.accessionId}
+                              data-schema={item.schema}
+                            />
+                            <Button
+                              className={classes.viewButton}
+                              aria-label="View draft"
+                              variant="outlined"
+                              size="small"
+                              onClick={() => {}}
+                            >
+                              View
+                            </Button>
+                          </div>
+                        }
+                      />
+                    ))}
+                  </FormGroup>
+                </FormControl>
+              )}
+            </ConnectForm>
+          )
+        })}
+        <Button
+          className={classes.publishButton}
+          variant="contained"
+          aria-label="Publish folder contents and move to frontpage"
+          color="primary"
+          type="submit"
+        >
+          Publish
+        </Button>
+      </form>
+    </FormProvider>
+  )
+}
+
+export default WizardDraftSelections

--- a/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
@@ -92,11 +92,13 @@ const WizardFooter = (): React$Element<any> => {
           setErrorPrefix(`Couldn't publish folder with id ${folder.folderId}`)
         })
 
-      dispatch(addDraftsToUser("current", formData)).catch(error => {
-        setConnError(true)
-        setResponseError(JSON.parse(error))
-        setErrorPrefix("Can't save drafts for user")
-      })
+      formData && formData?.length > 0
+        ? dispatch(addDraftsToUser("current", formData)).catch(error => {
+            setConnError(true)
+            setResponseError(JSON.parse(error))
+            setErrorPrefix("Can't save drafts for user")
+          })
+        : null
     } else {
       setDialogOpen(false)
     }

--- a/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardFooter.js
@@ -12,8 +12,10 @@ import WizardStatusMessageHandler from "../WizardForms/WizardStatusMessageHandle
 import WizardAlert from "./WizardAlert"
 
 import { WizardStatus } from "constants/wizardStatus"
+import { addDraftsToUser } from "features/userSlice"
 import { resetObjectType } from "features/wizardObjectTypeSlice"
 import { deleteFolderAndContent, publishFolderContent, resetFolder } from "features/wizardSubmissionFolderSlice"
+import type { ObjectInsideFolderWithTags } from "types"
 import { useQuery } from "utils"
 
 const useStyles = makeStyles(theme => ({
@@ -50,6 +52,7 @@ const WizardFooter = (): React$Element<any> => {
   const classes = useStyles()
   const dispatch = useDispatch()
   const folder = useSelector(state => state.submissionFolder)
+
   const [dialogOpen, setDialogOpen] = useState(false)
   const [alertType, setAlertType] = useState("")
   const [connError, setConnError] = useState(false)
@@ -68,7 +71,7 @@ const WizardFooter = (): React$Element<any> => {
     dispatch(resetFolder())
   }
 
-  const handleAlert = alertWizard => {
+  const handleAlert = (alertWizard: boolean, formData?: Array<ObjectInsideFolderWithTags>) => {
     setConnError(false)
     if (alertWizard && alertType === "cancel") {
       dispatch(deleteFolderAndContent(folder))
@@ -88,6 +91,12 @@ const WizardFooter = (): React$Element<any> => {
           setResponseError(JSON.parse(error))
           setErrorPrefix(`Couldn't publish folder with id ${folder.folderId}`)
         })
+
+      dispatch(addDraftsToUser("current", formData)).catch(error => {
+        setConnError(true)
+        setResponseError(JSON.parse(error))
+        setErrorPrefix("Can't save drafts for user")
+      })
     } else {
       setDialogOpen(false)
     }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -43,3 +43,19 @@ export const fetchUserById = (userId: string): ((dispatch: (any) => void) => Pro
     }
   })
 }
+
+export const addDraftsToUser = (
+  userId: string,
+  drafts: any
+): ((dispatch: (any) => void) => Promise<any>) => async () => {
+  const changes = [{ op: "add", path: "/drafts/-", value: drafts }]
+  const response = await userAPIService.patchUserById("current", changes)
+
+  return new Promise((resolve, reject) => {
+    if (response.ok) {
+      resolve(response)
+    } else {
+      reject(JSON.stringify(response))
+    }
+  })
+}

--- a/src/services/errorMonitor.js
+++ b/src/services/errorMonitor.js
@@ -3,7 +3,7 @@ export const errorMonitor = res => {
   if (!res.ok) {
     switch (res.status) {
       case 401:
-        // window.location = "/error401"
+        window.location = "/error401"
         break
       case 403:
         window.location = "/error403"

--- a/src/services/errorMonitor.js
+++ b/src/services/errorMonitor.js
@@ -3,7 +3,7 @@ export const errorMonitor = res => {
   if (!res.ok) {
     switch (res.status) {
       case 401:
-        window.location = "/error401"
+        // window.location = "/error401"
         break
       case 403:
         window.location = "/error403"

--- a/src/services/usersAPI.js
+++ b/src/services/usersAPI.js
@@ -14,7 +14,12 @@ const deleteUserById = async (userID: string): Promise<any> => {
   return await api.delete(`/${userID}`)
 }
 
+const patchUserById = async (userID: string, changes: any): Promise<any> => {
+  return await api.patch(`/${userID}`, changes)
+}
+
 export default {
   getUserById,
   deleteUserById,
+  patchUserById,
 }


### PR DESCRIPTION
### Description

- Drafts will be shown to users to save as templates before  publishing folders

### Related issues

Closes https://github.com/CSCfi/metadata-submitter-frontend/issues/155

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Add a form for selecting drafts in component `WizardDraftSelections`
- Add option to `View` the draft
- Add `Cancel` button to close the `Publish dialog`
- Add e2e test for showing draft selections
- Fix e2e test for error 401

### Testing

- [x] Integration Tests

### Mentions

List of drafts saved as templates will be implemented in the next PR (for issuse https://github.com/CSCfi/metadata-submitter-frontend/issues/141)