### PR TITLE
Feature/user draft templates

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -9,7 +9,8 @@ describe("Basic e2e", function () {
   it("should create new folder, add Study form, upload Study XML file, add Analysis form, and publish folder", () => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
 
     // Navigate to folder creation
     cy.get("button[type=button]").contains("New folder").click()
@@ -38,7 +39,7 @@ describe("Basic e2e", function () {
     // Edit saved submission
     cy.get("button[type=button]").contains("Edit").click()
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title")
-    cy.get("input[name='descriptor.studyTitle']", { timeout: 10000 }).type(" edited")
+    cy.get("input[name='descriptor.studyTitle']", { timeout: 10000 }).focus().type(" edited")
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title edited")
     cy.get("button[type=button]").contains("Update").click()
     cy.get("div[role=alert]").contains("Object updated")

--- a/cypress/integration/draft.spec.js
+++ b/cypress/integration/draft.spec.js
@@ -56,7 +56,7 @@ describe("Draft operations", function () {
     cy.get("button[type=button]").contains("Update draft").click()
 
     // Create a new form and save as draft
-    cy.get("button", { timeout: 10000 }).contains("New form").click()
+    cy.get("button", { timeout: 10000 }).contains("New form").click({ force: true })
     cy.get("input[name='descriptor.studyTitle']").should("contain.text", "")
     cy.get("input[name='descriptor.studyTitle']").type("New title 2")
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title 2")

--- a/cypress/integration/draft.spec.js
+++ b/cypress/integration/draft.spec.js
@@ -4,7 +4,8 @@ describe("Draft operations", function () {
   it("should create new folder, save, delete and continue draft", () => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
 
     // Navigate to folder creation
     cy.get("button[type=button]").contains("New folder").click()
@@ -55,7 +56,7 @@ describe("Draft operations", function () {
     cy.get("button[type=button]").contains("Update draft").click()
 
     // Create a new form and save as draft
-    cy.get("button").contains("New form").click()
+    cy.get("button", { timeout: 10000 }).contains("New form").click()
     cy.get("input[name='descriptor.studyTitle']").should("contain.text", "")
     cy.get("input[name='descriptor.studyTitle']").type("New title 2")
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title 2")

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -35,12 +35,20 @@ describe("draft selections and templates", function () {
     cy.get("button[type=button]").contains("Save as Draft").click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
+    cy.get("div[role=button]").contains("Study").click()
+
     // Create and Save another draft - Sample draft
-    cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click({ force: true })
-    cy.get("div[role=button]")
-      .contains("Fill Form", { timeout: 10000 })
-      .should("be.visible")
-      .then($btn => $btn.click())
+    cy.get("div[role=button]").contains("Sample", { timeout: 10000 }).click()
+    cy.wait(500)
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Fill Form", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
 
     cy.get("input[name='title']").type("Sample draft title ")
     cy.get("input[name='sampleName.taxonId']").type(123)
@@ -103,10 +111,16 @@ describe("draft selections and templates", function () {
 
     // Create and Save another draft - Sample draft
     cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click({ force: true })
-    cy.get("div[role=button]")
-      .contains("Fill Form", { timeout: 10000 })
-      .should("be.visible")
-      .then($btn => $btn.click())
+    cy.wait(500)
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Fill Form", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
 
     cy.get("input[name='title']").type("Sample draft title")
     cy.get("input[name='sampleName.taxonId']").type(123)

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -36,9 +36,9 @@ describe("draft selections and templates", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Create and Save another draft - Sample draft
-    cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click()
+    cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click({ force: true })
     cy.get("div[role=button]")
-      .contains("Fill Form")
+      .contains("Fill Form", { timeout: 10000 })
       .should("be.visible")
       .then($btn => $btn.click())
 
@@ -102,9 +102,9 @@ describe("draft selections and templates", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Create and Save another draft - Sample draft
-    cy.get("div[role=button]").contains("Sample").click()
-    cy.get("div[role=button]", { timeout: 10000 })
-      .contains("Fill Form")
+    cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click({ force: true })
+    cy.get("div[role=button]")
+      .contains("Fill Form", { timeout: 10000 })
       .should("be.visible")
       .then($btn => $btn.click())
 

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -4,10 +4,10 @@ describe("draft selections and templates", function () {
   beforeEach(() => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
-
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
     // Navigate to folder creation
-    cy.get("button[type=button]").contains("New folder").click()
+    cy.get("button[type=button]", { timeout: 10000 }).contains("New folder").click()
 
     // Add folder name & description, navigate to submissions
     cy.get("input[name='name']").type("Test name")
@@ -15,9 +15,9 @@ describe("draft selections and templates", function () {
     cy.get("button[type=button]").contains("Next").click()
   })
 
-  it("should show the list of drafts before folder is published", () => {
+  it("should show the list of drafts before folder is published, and show saved drafts in Home page", () => {
     // Fill a Study form
-    cy.get("div[role=button]").contains("Study").click()
+    cy.get("div[role=button]", { timeout: 10000 }).contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()
     cy.get("input[name='descriptor.studyTitle']").type("Study test title")
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "Study test title")
@@ -64,6 +64,21 @@ describe("draft selections and templates", function () {
 
     // Navigate back to home page
     cy.get("div", { timeout: 10000 }).contains("Logged in as:")
+
+    // Check if the drafts have been saved as user's templates in Home page
+    cy.contains("Your Draft Templates").should("be.visible")
+    // Check saved Study draft
+    cy.get("h6").contains("Draft-study").as("studyObject")
+    cy.get("@studyObject")
+      .should("be.visible")
+      .then($el => $el.click())
+    cy.get("div[data-schema='draft-study']").contains("Study draft title").should("be.visible")
+    // Check saved Sample draft
+    cy.get("h6").contains("Draft-sample").as("sampleObject")
+    cy.get("@sampleObject")
+      .should("be.visible")
+      .then($el => $el.click())
+    cy.get("div[data-schema='draft-sample']").contains("Sample draft title").should("be.visible")
   })
 
   it("should open the correct draft when clicking View button", () => {

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -36,8 +36,8 @@ describe("draft selections and templates", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Create and Save another draft - Sample draft
-    cy.get("div[role=button]").contains("Sample").click()
-    cy.get("div[role=button]", { timeout: 10000 })
+    cy.get("div[role=button]", { timeout: 10000 }).contains("Sample").click()
+    cy.get("div[role=button]")
       .contains("Fill Form")
       .should("be.visible")
       .then($btn => $btn.click())

--- a/cypress/integration/emptyForm.spec.js
+++ b/cypress/integration/emptyForm.spec.js
@@ -4,7 +4,8 @@ describe("empty form should not be alerted or saved", function () {
   it("should not show draft saving alert when form is empty, should not save an empty form", () => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
 
     // Navigate to folder creation
     cy.get("button[type=button]").contains("New folder").click()

--- a/cypress/integration/objectLinksAttributes.spec.js
+++ b/cypress/integration/objectLinksAttributes.spec.js
@@ -4,7 +4,8 @@ describe("render objects' links and attributes ", function () {
   it("should render correct Study Links and Attributes", () => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
 
     // Navigate to folder creation
     cy.get("button[type=button]").contains("New folder").click()

--- a/cypress/integration/objectTitles.spec.js
+++ b/cypress/integration/objectTitles.spec.js
@@ -4,8 +4,8 @@ describe("draft and submitted objects' titles", function () {
   beforeEach(() => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
-    cy.visit(baseUrl + "newdraft")
-
+    cy.wait(1000)
+    cy.get("button", { timeout: 10000 }).contains("Create Submission").click()
     // Navigate to folder creation
     cy.get("button[type=button]").contains("New folder").click()
     // Add folder name & description, navigate to submissions

--- a/src/components/Home/SubmissionIndexCard.js
+++ b/src/components/Home/SubmissionIndexCard.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles(theme => ({
     padding: 0,
   },
   submissionsListItems: {
-    border: "solid 1px #ccc",
+    border: `1px solid ${theme.palette.secondary.main}`,
     borderRadius: 3,
     margin: theme.spacing(1, 0),
     boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -1,33 +1,25 @@
 //@flow
 import React, { useState } from "react"
 
-// import Button from "@material-ui/core/Button"
 import Card from "@material-ui/core/Card"
-// import CardActions from "@material-ui/core/CardActions"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
-// import Collapse from "@material-ui/core/Collapse"
-// import IconButton from "@material-ui/core/IconButton"
-import List from "@material-ui/core/List"
+import Collapse from "@material-ui/core/Collapse"
+import IconButton from "@material-ui/core/IconButton"
 import ListItemText from "@material-ui/core/ListItemText"
 import { makeStyles } from "@material-ui/core/styles"
-// import TableCell from "@material-ui/core/TableCell"
-// import TableRow from "@material-ui/core/TableRow"
+import Table from "@material-ui/core/Table"
+import TableBody from "@material-ui/core/TableBody"
+import TableCell from "@material-ui/core/TableCell"
+import TableRow from "@material-ui/core/TableRow"
 import Typography from "@material-ui/core/Typography"
-// import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
-// import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp"
+import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
+import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp"
 import { useSelector } from "react-redux"
 
-import { getDraftObjects, getItemPrimaryText, formatDisplayObjectType } from "utils"
-// import { useHistory } from "react-router-dom"
-
-// import { ObjectSubmissionTypes, ObjectStatus } from "constants/wizardObject"
-// import { WizardStatus } from "constants/wizardStatus"
-
-// import { updateStatus } from "features/wizardStatusMessageSlice"
+import { formatDisplayObjectType, getDraftObjects, getItemPrimaryText } from "utils"
 
 const useStyles = makeStyles(theme => ({
-  border: theme.palette.primary,
   card: {
     height: "100%",
     display: "flex",
@@ -40,8 +32,7 @@ const useStyles = makeStyles(theme => ({
     padding: 0,
     marginTop: theme.spacing(1),
   },
-  cardContent: { flexGrow: 1, padding: 0 },
-  list: { padding: 0 },
+  table: { padding: 0, margin: theme.spacing(1, 0) },
   schemaTitle: {
     color: theme.palette.grey[900],
     padding: theme.spacing(1),
@@ -49,18 +40,30 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
-    border: `1px solid ${theme.palette.secondary.main}`,
-    borderRadius: 3,
+    alignItems: "center",
+    border: `0.1rem solid ${theme.palette.secondary.main}`,
+    borderRadius: "0.125rem",
     margin: theme.spacing(1, 0),
     boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
+    "&:hover": {
+      cursor: "pointer",
+    },
+  },
+  listItems: {
+    border: "none",
   },
   collapse: {
-    borderTop: `3px solid ${theme.palette.primary.main}`,
+    border: `0.1rem solid ${theme.palette.secondary.main}`,
+    padding: theme.spacing(1),
+    borderRadius: "0.125rem",
   },
   listItemText: {
     padding: 0,
     margin: theme.spacing(1, 0),
-    borderBottom: `solid 1px ${theme.palette.secondary.main}`,
+    borderBottom: `solid 0.1rem ${theme.palette.secondary.main}`,
+    "&:last-child": {
+      border: "none",
+    },
   },
 }))
 
@@ -71,36 +74,46 @@ const UserDraftTemplates = (): React$Element<any> => {
 
   const draftObjects = getDraftObjects(user.drafts, objectsArray)
 
-  const [open, setOpen] = useState(false)
-
   // Render when there is user's draft template(s)
   const DraftList = () => (
-    <CardContent className={classes.cardContent}>
-      {draftObjects.map(draft => {
-        const schema = Object.keys(draft)[0]
-        return (
-          <List key={schema} aria-label={schema} className={classes.list}>
-            <div className={classes.schemaTitle} onClick={() => setOpen(!open)}>
-              <Typography display="inline" variant="subtitle1" fontWeight="fontWeightBold">
-                {formatDisplayObjectType(schema)}
-              </Typography>
-            </div>
+    <Table className={classes.table}>
+      <TableBody>
+        {draftObjects.map(draft => {
+          const schema = Object.keys(draft)[0]
+          const [open, setOpen] = useState(false)
 
-            <div>
-              {draft[schema].map(item => (
-                <ListItemText
-                  className={classes.listItemText}
-                  key={item.accessionId}
-                  primary={getItemPrimaryText(item)}
-                  secondary={item.accessionId}
-                  data-schema={item.schema}
-                />
-              ))}
-            </div>
-          </List>
-        )
-      })}
-    </CardContent>
+          return (
+            <React.Fragment key={schema}>
+              <TableRow onClick={() => setOpen(!open)}>
+                <TableCell className={classes.schemaTitle}>
+                  <Typography display="inline" variant="subtitle1">
+                    {formatDisplayObjectType(schema)}
+                  </Typography>
+                  <IconButton aria-label="expand row" size="small">
+                    {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell padding="none" className={classes.listItems}>
+                  <Collapse className={classes.collapse} in={open} timeout={{ enter: 150, exit: 150 }} unmountOnExit>
+                    {draft[schema].map(item => (
+                      <ListItemText
+                        className={classes.listItemText}
+                        key={item.accessionId}
+                        primary={getItemPrimaryText(item)}
+                        secondary={item.accessionId}
+                        data-schema={item.schema}
+                      />
+                    ))}
+                  </Collapse>
+                </TableCell>
+              </TableRow>
+            </React.Fragment>
+          )
+        })}
+      </TableBody>
+    </Table>
   )
 
   // Renders when user has no draft templates
@@ -111,6 +124,7 @@ const UserDraftTemplates = (): React$Element<any> => {
       </Typography>
     </CardContent>
   )
+
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -72,7 +72,7 @@ const UserDraftTemplates = (): React$Element<any> => {
   const user = useSelector(state => state.user)
   const objectsArray = useSelector(state => state.objectsArray)
 
-  const draftObjects = getDraftObjects(user.drafts, objectsArray)
+  const draftObjects = user.drafts ? getDraftObjects(user.drafts, objectsArray) : []
 
   // Render when there is user's draft template(s)
   const DraftList = () => (

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -128,7 +128,7 @@ const UserDraftTemplates = (): React$Element<any> => {
   return (
     <Card className={classes.card} variant="outlined">
       <CardHeader
-        title={"Your draft templates"}
+        title={"Your Draft Templates"}
         titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
         className={classes.cardTitle}
       />

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -1,0 +1,88 @@
+//@flow
+import React from "react"
+
+// import Button from "@material-ui/core/Button"
+import Card from "@material-ui/core/Card"
+// import CardActions from "@material-ui/core/CardActions"
+import CardContent from "@material-ui/core/CardContent"
+import CardHeader from "@material-ui/core/CardHeader"
+import List from "@material-ui/core/List"
+import ListItemText from "@material-ui/core/ListItemText"
+import { makeStyles } from "@material-ui/core/styles"
+import Typography from "@material-ui/core/Typography"
+import { useSelector } from "react-redux"
+
+import { getDraftObjects, getItemPrimaryText, formatDisplayObjectType } from "utils"
+// import { useHistory } from "react-router-dom"
+
+// import { ObjectSubmissionTypes, ObjectStatus } from "constants/wizardObject"
+// import { WizardStatus } from "constants/wizardStatus"
+
+// import { updateStatus } from "features/wizardStatusMessageSlice"
+
+const useStyles = makeStyles(theme => ({
+  border: theme.palette.primary,
+  card: {},
+  cardTitle: {},
+  cardContent: {},
+  list: {},
+}))
+
+// type UserDraftTemplatesProps = {
+
+// }
+
+const UserDraftTemplates = (): React$Element<any> => {
+  const classes = useStyles()
+  const user = useSelector(state => state.user)
+  const objectsArray = useSelector(state => state.objectsArray)
+
+  const draftObjects = getDraftObjects(user.drafts, objectsArray)
+  console.log("draftObjects :>> ", draftObjects)
+  //
+  const DraftList = () => (
+    <CardContent className={classes.cardContent}>
+      {draftObjects.map(draft => {
+        const schema = Object.keys(draft)[0]
+        return (
+          <List key={schema} aria-label={schema} className={classes.list}>
+            <Typography variant="subtitle1" fontWeight="fontWeightBold">
+              {formatDisplayObjectType(schema)}
+            </Typography>
+            <div>
+              {draft[schema].map(item => (
+                <ListItemText
+                  key={item.accessionId}
+                  primary={getItemPrimaryText(item)}
+                  secondary={item.accessionId}
+                  data-schema={item.schema}
+                />
+              ))}
+            </div>
+          </List>
+        )
+      })}
+    </CardContent>
+  )
+
+  // Renders when user has no draft templates
+  const EmptyList = () => (
+    <CardContent className={classes.cardContent}>
+      <Typography align="center" variant="body2">
+        Currently there are no draft templates.
+      </Typography>
+    </CardContent>
+  )
+  return (
+    <Card className={classes.card} variant="outlined">
+      <CardHeader
+        title={"Your draft templates"}
+        titleTypographyProps={{ variant: "subtitle1", fontWeight: "fontWeightBold" }}
+        className={classes.cardTitle}
+      />
+      {draftObjects.length > 0 ? <DraftList /> : <EmptyList />}
+    </Card>
+  )
+}
+
+export default UserDraftTemplates

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -1,15 +1,21 @@
 //@flow
-import React from "react"
+import React, { useState } from "react"
 
 // import Button from "@material-ui/core/Button"
 import Card from "@material-ui/core/Card"
 // import CardActions from "@material-ui/core/CardActions"
 import CardContent from "@material-ui/core/CardContent"
 import CardHeader from "@material-ui/core/CardHeader"
+// import Collapse from "@material-ui/core/Collapse"
+// import IconButton from "@material-ui/core/IconButton"
 import List from "@material-ui/core/List"
 import ListItemText from "@material-ui/core/ListItemText"
 import { makeStyles } from "@material-ui/core/styles"
+// import TableCell from "@material-ui/core/TableCell"
+// import TableRow from "@material-ui/core/TableRow"
 import Typography from "@material-ui/core/Typography"
+// import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
+// import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp"
 import { useSelector } from "react-redux"
 
 import { getDraftObjects, getItemPrimaryText, formatDisplayObjectType } from "utils"
@@ -22,15 +28,41 @@ import { getDraftObjects, getItemPrimaryText, formatDisplayObjectType } from "ut
 
 const useStyles = makeStyles(theme => ({
   border: theme.palette.primary,
-  card: {},
-  cardTitle: {},
-  cardContent: {},
-  list: {},
+  card: {
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    border: "none",
+    padding: theme.spacing(0),
+  },
+  cardTitle: {
+    fontSize: "0.5em",
+    padding: 0,
+    marginTop: theme.spacing(1),
+  },
+  cardContent: { flexGrow: 1, padding: 0 },
+  list: { padding: 0 },
+  schemaTitle: {
+    color: theme.palette.grey[900],
+    padding: theme.spacing(1),
+    textTransform: "capitalize",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    border: `1px solid ${theme.palette.secondary.main}`,
+    borderRadius: 3,
+    margin: theme.spacing(1, 0),
+    boxShadow: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
+  },
+  collapse: {
+    borderTop: `3px solid ${theme.palette.primary.main}`,
+  },
+  listItemText: {
+    padding: 0,
+    margin: theme.spacing(1, 0),
+    borderBottom: `solid 1px ${theme.palette.secondary.main}`,
+  },
 }))
-
-// type UserDraftTemplatesProps = {
-
-// }
 
 const UserDraftTemplates = (): React$Element<any> => {
   const classes = useStyles()
@@ -38,20 +70,26 @@ const UserDraftTemplates = (): React$Element<any> => {
   const objectsArray = useSelector(state => state.objectsArray)
 
   const draftObjects = getDraftObjects(user.drafts, objectsArray)
-  console.log("draftObjects :>> ", draftObjects)
-  //
+
+  const [open, setOpen] = useState(false)
+
+  // Render when there is user's draft template(s)
   const DraftList = () => (
     <CardContent className={classes.cardContent}>
       {draftObjects.map(draft => {
         const schema = Object.keys(draft)[0]
         return (
           <List key={schema} aria-label={schema} className={classes.list}>
-            <Typography variant="subtitle1" fontWeight="fontWeightBold">
-              {formatDisplayObjectType(schema)}
-            </Typography>
+            <div className={classes.schemaTitle} onClick={() => setOpen(!open)}>
+              <Typography display="inline" variant="subtitle1" fontWeight="fontWeightBold">
+                {formatDisplayObjectType(schema)}
+              </Typography>
+            </div>
+
             <div>
               {draft[schema].map(item => (
                 <ListItemText
+                  className={classes.listItemText}
                   key={item.accessionId}
                   primary={getItemPrimaryText(item)}
                   secondary={item.accessionId}

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -21,7 +21,7 @@ import { updateStatus } from "features/wizardStatusMessageSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import draftAPIService from "services/draftAPI"
 import type { ObjectInsideFolderWithTags } from "types"
-import { getItemPrimaryText } from "utils"
+import { getItemPrimaryText, getDraftObjects } from "utils"
 
 const useStyles = makeStyles(theme => ({
   formComponent: {
@@ -98,12 +98,7 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
   const objectsArray = useSelector(state => state.objectsArray)
   const history = useHistory()
 
-  // draftObjects contains an array of objects and each has a schema and the related draft(s) array if there is any
-  const draftObjects = objectsArray.flatMap((schema: string) => {
-    const draftSchema = `draft-${schema}`
-    const draftArray = folder.drafts.filter(draft => draft.schema.toLowerCase() === draftSchema.toLowerCase())
-    return draftArray.length > 0 ? [{ [`draft-${schema}`]: draftArray }] : []
-  })
+  const draftObjects = getDraftObjects(folder.drafts, objectsArray)
 
   const methods = useForm()
 

--- a/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardObjectIndex.js
@@ -1,5 +1,5 @@
 //@flow
-import React, { useState, useEffect } from "react"
+import React, { useState } from "react"
 
 import MuiAccordion from "@material-ui/core/Accordion"
 import MuiAccordionDetails from "@material-ui/core/AccordionDetails"
@@ -16,15 +16,13 @@ import { useDispatch, useSelector } from "react-redux"
 
 import WizardAlert from "./WizardAlert"
 
-import { ObjectSubmissionTypes, ObjectSubmissionsArray, ObjectTypes } from "constants/wizardObject"
+import { ObjectSubmissionTypes, ObjectSubmissionsArray } from "constants/wizardObject"
 import { resetDraftStatus } from "features/draftStatusSlice"
 import { setFocus } from "features/focusSlice"
-import { setObjectsArray } from "features/objectsArraySlice"
 import { resetCurrentObject } from "features/wizardCurrentObjectSlice"
 import { setObjectType } from "features/wizardObjectTypeSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
-import schemaAPIService from "services/schemaAPI"
-import {formatDisplayObjectType} from "utils"
+import { formatDisplayObjectType } from "utils"
 
 const useStyles = makeStyles(theme => ({
   index: {
@@ -249,8 +247,8 @@ const WizardObjectIndex = (): React$Element<any> => {
   const currentObjectType = useSelector(state => state.objectType)
   const currentSubmissionType = useSelector(state => state.submissionType)
   const draftStatus = useSelector(state => state.draftStatus)
-
   const folder = useSelector(state => state.submissionFolder)
+
   // Get draft objects of current folder
   // and count the amount of drafts of each existing objectType
   const draftObjects = folder.drafts
@@ -260,43 +258,6 @@ const WizardObjectIndex = (): React$Element<any> => {
   const savedObjects = folder.metadataObjects
     ?.map(draft => draft.schema)
     .reduce((acc, val) => ((acc[val] = (acc[val] || 0) + 1), acc), {})
-  // Fetch array of schemas from backend and store it in frontend
-  // Fetch only if the initial array is empty
-  // if there is any errors while fetching, it will return a manually created ObjectsArray instead
-  useEffect(() => {
-    if (objectsArray.length === 0) {
-      let isMounted = true
-      const getSchemas = async () => {
-        const response = await schemaAPIService.getAllSchemas()
-
-        if (isMounted) {
-          if (response.ok) {
-            const schemas = response.data
-              .filter(schema => schema.title !== "Project" && schema.title !== "Submission")
-              .map(schema => schema.title.toLowerCase())
-            dispatch(setObjectsArray(schemas))
-          } else {
-            dispatch(
-              setObjectsArray([
-                ObjectTypes.study,
-                ObjectTypes.sample,
-                ObjectTypes.experiment,
-                ObjectTypes.run,
-                ObjectTypes.analysis,
-                ObjectTypes.dac,
-                ObjectTypes.policy,
-                ObjectTypes.dataset,
-              ])
-            )
-          }
-        }
-      }
-      getSchemas()
-      return () => {
-        isMounted = false
-      }
-    }
-  }, [])
 
   const handlePanelChange = panel => (event, newExpanded) => {
     setExpandedObjectType(newExpanded ? panel : false)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,6 +39,9 @@ export const useQuery = (): URLSearchParams => {
 export const formatDisplayObjectType = (objectType: string): string => {
   if (objectType === ObjectTypes.dac) {
     return `${objectType.toUpperCase()}`
+  } else if (objectType === `draft-${ObjectTypes.dac}`) {
+    const hyphenIndex = objectType.indexOf("-")
+    return `draft-${objectType.slice(hyphenIndex + 1).toUpperCase()}`
   } else {
     return `${objectType.charAt(0).toUpperCase()}${objectType.slice(1)}`
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -51,7 +51,6 @@ export const getDraftObjects = (drafts: Array<ObjectInsideFolderWithTags>, objec
     const draftArray = drafts.filter(draft => draft.schema.toLowerCase() === draftSchema.toLowerCase())
     return draftArray.length > 0 ? [{ [`draft-${schema}`]: draftArray }] : []
   })
-  console.log("drafts :>> ", drafts)
-  console.log("draftObjects :>> ", draftObjects)
+
   return draftObjects
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 //@flow
+
 import { useLocation } from "react-router-dom"
 
 import { ObjectTypes } from "constants/wizardObject"
@@ -15,6 +16,7 @@ export const getObjectDisplayTitle = (objectType: string, cleanedValues: any): s
   }
 }
 
+// Get Primary text for displaying item's title
 export const getItemPrimaryText = (item: ObjectInsideFolderWithTags): string => {
   if (item.tags?.displayTitle) {
     switch (item.schema) {
@@ -35,9 +37,21 @@ export const useQuery = (): URLSearchParams => {
 }
 
 export const formatDisplayObjectType = (objectType: string): string => {
-if (objectType === ObjectTypes.dac){
+  if (objectType === ObjectTypes.dac) {
     return `${objectType.toUpperCase()}`
   } else {
     return `${objectType.charAt(0).toUpperCase()}${objectType.slice(1)}`
   }
+}
+
+// draftObjects contains an array of objects and each has a schema and the related draft(s) array if there is any
+export const getDraftObjects = (drafts: Array<ObjectInsideFolderWithTags>, objectsArray: Array<string>) => {
+  const draftObjects = objectsArray.flatMap((schema: string) => {
+    const draftSchema = `draft-${schema}`
+    const draftArray = drafts.filter(draft => draft.schema.toLowerCase() === draftSchema.toLowerCase())
+    return draftArray.length > 0 ? [{ [`draft-${schema}`]: draftArray }] : []
+  })
+  console.log("drafts :>> ", drafts)
+  console.log("draftObjects :>> ", draftObjects)
+  return draftObjects
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -48,7 +48,7 @@ export const formatDisplayObjectType = (objectType: string): string => {
 }
 
 // draftObjects contains an array of objects and each has a schema and the related draft(s) array if there is any
-export const getDraftObjects = (drafts: Array<ObjectInsideFolderWithTags>, objectsArray: Array<string>) => {
+export const getDraftObjects = (drafts: Array<ObjectInsideFolderWithTags>, objectsArray: Array<string>): any => {
   const draftObjects = objectsArray.flatMap((schema: string) => {
     const draftSchema = `draft-${schema}`
     const draftArray = drafts.filter(draft => draft.schema.toLowerCase() === draftSchema.toLowerCase())

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -9,13 +9,17 @@ import Typography from "@material-ui/core/Typography"
 import { useDispatch, useSelector } from "react-redux"
 
 import SubmissionIndexCard from "components/Home/SubmissionIndexCard"
+import UserDraftTemplates from "components/Home/UserDraftTemplates"
 import WizardStatusMessageHandler from "components/NewDraftWizard/WizardForms/WizardStatusMessageHandler"
 import { FolderSubmissionStatus } from "constants/wizardFolder"
+import { ObjectTypes } from "constants/wizardObject"
 import { WizardStatus } from "constants/wizardStatus"
+import { setObjectsArray } from "features/objectsArraySlice"
 import { setPublishedFolders } from "features/publishedFoldersSlice"
 import { setUnpublishedFolders } from "features/unpublishedFoldersSlice"
 import { fetchUserById } from "features/userSlice"
 import folderAPIService from "services/folderAPI"
+import schemaAPIService from "services/schemaAPI"
 
 const useStyles = makeStyles(theme => ({
   tableCard: {
@@ -32,6 +36,8 @@ const useStyles = makeStyles(theme => ({
 const Home = (): React$Element<typeof Grid> => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.user)
+  console.log("user :>> ", user)
+  const objectsArray = useSelector(state => state.objectsArray)
 
   const unpublishedFolders = useSelector(state => state.unpublishedFolders)
   const publishedFolders = useSelector(state => state.publishedFolders)
@@ -70,6 +76,44 @@ const Home = (): React$Element<typeof Grid> => {
     }
   }, [])
 
+  // Fetch array of schemas from backend and store it in frontend
+  // Fetch only if the initial array is empty
+  // if there is any errors while fetching, it will return a manually created ObjectsArray instead
+  useEffect(() => {
+    if (objectsArray.length === 0) {
+      let isMounted = true
+      const getSchemas = async () => {
+        const response = await schemaAPIService.getAllSchemas()
+
+        if (isMounted) {
+          if (response.ok) {
+            const schemas = response.data
+              .filter(schema => schema.title !== "Project" && schema.title !== "Submission")
+              .map(schema => schema.title.toLowerCase())
+            dispatch(setObjectsArray(schemas))
+          } else {
+            dispatch(
+              setObjectsArray([
+                ObjectTypes.study,
+                ObjectTypes.sample,
+                ObjectTypes.experiment,
+                ObjectTypes.run,
+                ObjectTypes.analysis,
+                ObjectTypes.dac,
+                ObjectTypes.policy,
+                ObjectTypes.dataset,
+              ])
+            )
+          }
+        }
+      }
+      getSchemas()
+      return () => {
+        isMounted = false
+      }
+    }
+  }, [])
+
   // Contains both unpublished and published folders (max. 5 items/each)
   return (
     <Grid container direction="column" justify="space-between" alignItems="stretch">
@@ -96,6 +140,10 @@ const Home = (): React$Element<typeof Grid> => {
               location="published"
               displayButton={true}
             />
+          </Grid>
+          <Divider variant="middle" />
+          <Grid item xs={12} className={classes.tableCard}>
+            <UserDraftTemplates />
           </Grid>
         </>
       )}

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -36,7 +36,6 @@ const useStyles = makeStyles(theme => ({
 const Home = (): React$Element<typeof Grid> => {
   const dispatch = useDispatch()
   const user = useSelector(state => state.user)
-  console.log("user :>> ", user)
   const objectsArray = useSelector(state => state.objectsArray)
 
   const unpublishedFolders = useSelector(state => state.unpublishedFolders)

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -79,7 +79,7 @@ const Home = (): React$Element<typeof Grid> => {
   // Fetch only if the initial array is empty
   // if there is any errors while fetching, it will return a manually created ObjectsArray instead
   useEffect(() => {
-    if (objectsArray.length === 0) {
+    if (objectsArray?.length === 0) {
       let isMounted = true
       const getSchemas = async () => {
         const response = await schemaAPIService.getAllSchemas()


### PR DESCRIPTION
### Description

- Drafts saved by users are listed in Home under **Your Draft Templates**
- Drafts are grouped according to their `objectType`

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/141

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Add component `UserDraftTemplate` to `Home` to show user's saved drafts
- Move `useEffect()` hook to fetch all `schemas` (`objectTypes`)  from `WizardObjectIndex` to `Home``
- Add e2e test for draft templates to `draftTemplates.spec.js`
- Fix the navigation to create a new folder for some other e2e tests (related to moving the `useEffect()` hook above)

### Testing

- [x] Integration Tests


### Mentions

- Future improvement: a separate url for each group of draft templates and possibly the implementation of pagination