### PR TITLE
Bugfix/wrong prefilled inputs in forms

### DIFF
--- a/cypress/integration/emptyForm.spec.js
+++ b/cypress/integration/emptyForm.spec.js
@@ -1,7 +1,7 @@
 describe("empty form should not be alerted or saved", function () {
   const baseUrl = "http://localhost:" + Cypress.env("port") + "/"
 
-  it("should not show draft saving alert when form is empty, should not save an empty form", () => {
+  beforeEach(() => {
     cy.visit(baseUrl)
     cy.get('[alt="CSC Login"]').click()
     cy.wait(1000)
@@ -14,7 +14,101 @@ describe("empty form should not be alerted or saved", function () {
     cy.get("input[name='name']").type("Test name")
     cy.get("textarea[name='description']").type("Test description")
     cy.get("button[type=button]").contains("Next").click()
+  })
 
+  it("should have New form button and Clear form button emptied the form", () => {
+    // Check Clear form button in Sample object
+    cy.get("div[role=button]").contains("Sample", { timeout: 10000 }).click()
+    cy.wait(500)
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Fill Form", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
+    cy.get("input[data-testid='title']").type("Test sample")
+    cy.get("input[data-testid='sampleName.taxonId']").type(123)
+    cy.get("button[type='button']").contains("Clear form").click()
+    cy.get("input[data-testid='title']").should("have.value", "")
+    cy.get("input[data-testid='sampleName.taxonId']").should("have.value", "")
+
+    // Check both New form button and Clear form button with Experiment object
+    cy.get("div[role=button]").contains("Experiment").click()
+    cy.wait(500)
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Fill Form", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
+
+    // Check if New form button can empty the form
+    cy.get("form")
+    cy.get("button[type='button']", { timeout: 10000 }).contains("New form").click()
+    cy.get("input[data-testid='title']").should("have.value", "")
+    cy.get("textarea[data-testid='description']").should("have.value", "")
+
+    // Fill in the form an check if Clear form button can empty the form
+    cy.get("input[data-testid='title']").type("Test experiment")
+    cy.get("textarea[data-testid='description']").type("Test experiment description")
+    cy.get("button[type='button']").contains("Clear form").click()
+    cy.get("input[data-testid='title']").should("have.value", "")
+    cy.get("textarea[data-testid='description']").should("have.value", "")
+
+    // Fill in the form again and save as draft
+    cy.get("input[data-testid='title']").type("Test experiment")
+    cy.get("textarea[data-testid='description']").type("Test experiment description")
+    cy.get("button[type='button']").contains("Save as Draft").click()
+    cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
+
+    // Select the Experiment draft
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Choose from drafts", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
+    cy.get("button[aria-label='Continue draft']").first().click()
+
+    cy.get("input[data-testid='title']").should("have.value", "Test experiment")
+    cy.get("textarea[data-testid='description']").should("have.value", "Test experiment description")
+
+    // Click Clear form button and expect the form is empty
+    cy.get("button[type='button']").contains("Clear form").click()
+    cy.get("input[data-testid='title']").should("have.value", "")
+    cy.get("textarea[data-testid='description']").should("have.value", "")
+
+    // Select the Experiment draft again
+    cy.get("div[aria-expanded='true']")
+      .siblings()
+      .within(() =>
+        cy
+          .get("div[role=button]")
+          .contains("Choose from drafts", { timeout: 10000 })
+          .should("be.visible")
+          .then($btn => $btn.click())
+      )
+    cy.get("button[aria-label='Continue draft']").first().click()
+
+    cy.get("input[data-testid='title']").should("have.value", "Test experiment")
+    cy.get("textarea[data-testid='description']").should("have.value", "Test experiment description")
+
+    // Click New form button and expect the form is empty
+    cy.get("button[type='button']").contains("New form").click()
+    cy.get("input[data-testid='title']").should("have.value", "")
+    cy.get("textarea[data-testid='description']").should("have.value", "")
+  })
+
+  it("should not show draft saving alert when form is empty, should not save an empty form", () => {
     // Focus on the Study title input in the Study form (not type anything)
     cy.get("div[role=button]").contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -226,10 +226,10 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   }
 
   const clearForm = () => {
-    methods.reset(formSchema)
+    resetTimer()
+    methods.reset({})
     setCleanedValues({})
     dispatch(resetDraftStatus())
-    resetTimer()
   }
 
   // Check if the form is empty
@@ -447,6 +447,7 @@ const WizardFillObjectDetailsForm = (): React$Element<typeof Container> => {
   useEffect(() => {
     const fetchSchema = async () => {
       let schema = sessionStorage.getItem(`cached_${objectType}_schema`)
+
       if (!schema || !new Ajv().validateSchema(JSON.parse(schema))) {
         const response = await schemaAPIService.getSchemaByObjectType(objectType)
         if (response.ok) {


### PR DESCRIPTION
### Description

Fix for buttons `New form` and `Clear form` to actually empty the form. No extra text in the inputs.

### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/248

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Fix method `reset` hook-form in `WizardFillObjectDetailsForm`
- Update e2e test for checking `New form` and `Clear form` buttons to actually empty the form

### Testing

- [x] Integration Tests


