### PR TITLE
Feature/react-hook-form v7 migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-hook-form": "^6.15.5",
+        "react-hook-form": "^7.3.4",
         "react-redux": "^7.2.4",
         "react-router-dom": "^5.2.0",
         "react-scripts": "^4.0.3"
@@ -18626,9 +18626,13 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "node_modules/react-hook-form": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.5.tgz",
-      "integrity": "sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.3.4.tgz",
+      "integrity": "sha512-xreG3NHFlbKFrN1Fs+rZUT5RN9zkx4qn0vyY+6tO1xNfhOkfgwkTYU1/PkktYsWw6GerMw16vX5CPdIZVfyB1A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17"
       }
@@ -39316,9 +39320,9 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "react-hook-form": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.5.tgz",
-      "integrity": "sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.3.4.tgz",
+      "integrity": "sha512-xreG3NHFlbKFrN1Fs+rZUT5RN9zkx4qn0vyY+6tO1xNfhOkfgwkTYU1/PkktYsWw6GerMw16vX5CPdIZVfyB1A==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^6.15.5",
+    "react-hook-form": "^7.3.4",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3"

--- a/src/App.js
+++ b/src/App.js
@@ -70,11 +70,7 @@ const App = (): React$Element<typeof React.Fragment> => {
   // Fetch only if the initial array is empty
   // if there is any errors while fetching, it will return a manually created ObjectsArray instead
   useEffect(() => {
-<<<<<<< HEAD
     if (location.pathname === "/" || pathsWithoutNav.indexOf(location.pathname) !== -1) return
-=======
-    if (location.pathname === "/") return
->>>>>>> 96bffca (Set object index array on app start)
     let isMounted = true
     const getSchemas = async () => {
       const response = await schemaAPIService.getAllSchemas()

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,11 @@ const App = (): React$Element<typeof React.Fragment> => {
   // Fetch only if the initial array is empty
   // if there is any errors while fetching, it will return a manually created ObjectsArray instead
   useEffect(() => {
+<<<<<<< HEAD
     if (location.pathname === "/" || pathsWithoutNav.indexOf(location.pathname) !== -1) return
+=======
+    if (location.pathname === "/") return
+>>>>>>> 96bffca (Set object index array on app start)
     let isMounted = true
     const getSchemas = async () => {
       const response = await schemaAPIService.getAllSchemas()

--- a/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardDraftSelections.js
@@ -139,46 +139,52 @@ const WizardDraftSelections = (props: WizardDraftSelectionsProps): React$Element
           const schema = Object.keys(draft)[0]
           return (
             <ConnectForm key={schema}>
-              {({ register }) => (
-                <FormControl className={classes.formControl} fullWidth>
-                  <FormLabel className={classes.formLabel}>{schema}</FormLabel>
-                  <FormGroup>
-                    {draft[schema].map(item => (
-                      <FormControlLabel
-                        key={item.accessionId}
-                        className={classes.formControlLabel}
-                        control={
-                          <Checkbox
-                            color="primary"
-                            name={item.accessionId}
-                            value={item.accessionId}
-                            inputRef={register}
+              {({ register }) => {
+                return (
+                  <FormControl className={classes.formControl} fullWidth>
+                    <FormLabel className={classes.formLabel}>{schema}</FormLabel>
+                    <FormGroup>
+                      {draft[schema].map(item => {
+                        const { ref, ...rest } = register(`${item.accessionId}`)
+                        return (
+                          <FormControlLabel
+                            key={item.accessionId}
+                            className={classes.formControlLabel}
+                            control={
+                              <Checkbox
+                                color="primary"
+                                name={item.accessionId}
+                                value={item.accessionId}
+                                {...rest}
+                                inputRef={ref}
+                              />
+                            }
+                            label={
+                              <div className={classes.label}>
+                                <ListItemText
+                                  className={classes.listItemText}
+                                  primary={getItemPrimaryText(item)}
+                                  secondary={item.accessionId}
+                                  data-schema={item.schema}
+                                />
+                                <Button
+                                  className={classes.viewButton}
+                                  aria-label="View draft"
+                                  variant="outlined"
+                                  size="small"
+                                  onClick={() => handleViewButton(item.schema, item.accessionId)}
+                                >
+                                  View
+                                </Button>
+                              </div>
+                            }
                           />
-                        }
-                        label={
-                          <div className={classes.label}>
-                            <ListItemText
-                              className={classes.listItemText}
-                              primary={getItemPrimaryText(item)}
-                              secondary={item.accessionId}
-                              data-schema={item.schema}
-                            />
-                            <Button
-                              className={classes.viewButton}
-                              aria-label="View draft"
-                              variant="outlined"
-                              size="small"
-                              onClick={() => handleViewButton(item.schema, item.accessionId)}
-                            >
-                              View
-                            </Button>
-                          </div>
-                        }
-                      />
-                    ))}
-                  </FormGroup>
-                </FormControl>
-              )}
+                        )
+                      })}
+                    </FormGroup>
+                  </FormControl>
+                )
+              }}
             </ConnectForm>
           )
         })}

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -146,11 +146,9 @@ const getDefaultValue = (nestedField?: any, name: string) => {
       } else {
         return
       }
-
     }
     return nestedField
-  }
-  else {
+  } else {
     return ""
   }
 }
@@ -348,6 +346,7 @@ const FormTextField = ({
     {({ register, errors }) => {
       const error = _.get(errors, name)
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
+      const { ref, ...rest } = register(`${name}`)
 
       return (
         <ValidationTextField
@@ -355,7 +354,8 @@ const FormTextField = ({
           inputProps={{ "data-testid": name }}
           label={label}
           role="textbox"
-          inputRef={register}
+          {...rest}
+          inputRef={ref}
           defaultValue={getDefaultValue(nestedField, name)}
           error={!!error}
           helperText={error?.message}
@@ -385,11 +385,14 @@ const FormSelectField = ({ name, label, required, options, nestedField }: FormSe
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
+      const { ref, ...rest } = register(`${name}`)
+
       return (
         <ValidationSelectField
           name={name}
           label={label}
-          inputRef={register}
+          {...rest}
+          inputRef={ref}
           defaultValue={getDefaultValue(nestedField, name)}
           error={!!error}
           helperText={error?.message}
@@ -416,11 +419,16 @@ const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
+      const { ref, ...rest } = register(`${name}`)
+
       return (
         <Box display="inline" px={1}>
           <FormControl error={!!error} required={required}>
             <FormGroup>
-              <FormControlLabel control={<Checkbox name={name} inputRef={register} defaultValue="" />} label={label} />
+              <FormControlLabel
+                control={<Checkbox name={name} {...rest} inputRef={ref} defaultValue="" />}
+                label={label}
+              />
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
           </FormControl>
@@ -441,13 +449,17 @@ const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldPr
     <ConnectForm>
       {({ register, errors }) => {
         const error = _.get(errors, name)
+        const { ref, ...rest } = register(`${name}`)
+
         return (
           <FormControl error={!!error} required={required}>
             <FormGroup>
               {options.map<React.Element<typeof FormControlLabel>>(option => (
                 <FormControlLabel
                   key={option}
-                  control={<Checkbox name={name} inputRef={register} value={option} color="primary" defaultValue="" />}
+                  control={
+                    <Checkbox name={name} {...rest} inputRef={ref} value={option} color="primary" defaultValue="" />
+                  }
                   label={option}
                 />
               ))}
@@ -527,4 +539,3 @@ export default {
   buildFields,
   cleanUpFormValues,
 }
-

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -516,7 +516,7 @@ const FormArray = ({ object, path }: FormArrayProps) => {
 
         return (
           <div className="arrayRow" key={`${name}[${index}]`}>
-            <Paper name="asd" elevation={2}>
+            <Paper elevation={2}>
               {Object.keys(items).map(item => {
                 const pathForThisIndex = [...pathWithoutLastItem, lastPathItemWithIndex, item]
                 return traverseFields(properties[item], pathForThisIndex, [], field)
@@ -528,7 +528,7 @@ const FormArray = ({ object, path }: FormArrayProps) => {
           </div>
         )
       })}
-      <Button variant="contained" color="primary" size="small" startIcon={<AddIcon />} onClick={() => append(items)}>
+      <Button variant="contained" color="primary" size="small" startIcon={<AddIcon />} onClick={() => append({})}>
         Add new item
       </Button>
     </div>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -285,6 +285,7 @@ const FormOneOfField = ({ path, object, nestedField }: { path: string[], object:
   const [field, setField] = useState(fieldValue)
 
   const handleChange = event => setField(event.target.value)
+
   const name = pathToName(path)
   const [lastPathItem] = path.slice(-1)
   const label = object.title ?? lastPathItem
@@ -346,7 +347,7 @@ const FormTextField = ({
     {({ register, errors }) => {
       const error = _.get(errors, name)
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
-      const { ref, ...rest } = register(`${name}`)
+      const { ref, ...rest } = register(name)
 
       return (
         <ValidationTextField
@@ -385,7 +386,7 @@ const FormSelectField = ({ name, label, required, options, nestedField }: FormSe
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
-      const { ref, ...rest } = register(`${name}`)
+      const { ref, ...rest } = register(name)
 
       return (
         <ValidationSelectField
@@ -419,7 +420,7 @@ const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
-      const { ref, ...rest } = register(`${name}`)
+      const { ref, ...rest } = register(name)
 
       return (
         <Box display="inline" px={1}>
@@ -449,7 +450,7 @@ const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldPr
     <ConnectForm>
       {({ register, errors }) => {
         const error = _.get(errors, name)
-        const { ref, ...rest } = register(`${name}`)
+        const { ref, ...rest } = register(name)
 
         return (
           <FormControl error={!!error} required={required}>

--- a/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardUploadObjectXMLForm.js
@@ -67,7 +67,13 @@ const WizardUploadObjectXMLForm = (): React$Element<typeof Container> => {
   const dispatch = useDispatch()
   const classes = useStyles()
   const currentObject = useSelector(state => state.currentObject)
-  const { register, errors, watch, handleSubmit, reset } = useForm({ mode: "onChange" })
+  const {
+    register,
+    watch,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm({ mode: "onChange" })
   const [placeHolder, setPlaceHolder] = useState("Name")
 
   const watchFile = watch("fileUpload")
@@ -192,11 +198,10 @@ const WizardUploadObjectXMLForm = (): React$Element<typeof Container> => {
             </Button>
             <input
               type="file"
-              name="fileUpload"
               id="file-select-button"
               data-testid="xml-upload"
               hidden
-              ref={register({
+              {...register("fileUpload", {
                 validate: {
                   isFile: value => value.length > 0,
                   isXML: value => value[0]?.type === "text/xml",

--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -3,7 +3,7 @@ import React, { useState } from "react"
 
 import { makeStyles } from "@material-ui/core/styles"
 import MuiTextField from "@material-ui/core/TextField"
-import { useForm } from "react-hook-form"
+import { useForm, Controller } from "react-hook-form"
 import { useDispatch, useSelector } from "react-redux"
 import { useHistory } from "react-router-dom"
 
@@ -33,8 +33,12 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
   const folder = useSelector(state => state.submissionFolder)
   const [connError, setConnError] = useState(false)
   const [responseError, setResponseError] = useState({})
-  const { register, errors, handleSubmit, formState } = useForm()
-  const { isSubmitting } = formState
+  const {
+    handleSubmit,
+    control,
+    formState: { isSubmitting },
+  } = useForm()
+
   const history = useHistory()
 
   const onSubmit = (data: FolderDataFromForm) => {
@@ -56,30 +60,42 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
   return (
     <>
       <form className={classes.root} onSubmit={handleSubmit(onSubmit)} ref={createFolderFormRef}>
-        <MuiTextField
+        <Controller
+          control={control}
           name="name"
-          label="Folder Name *"
-          variant="outlined"
-          fullWidth
-          inputRef={register({ required: true, validate: { name: value => value.length > 0 } })}
-          helperText={errors.name ? "Please give a name for folder." : null}
-          error={errors.name ? true : false}
-          disabled={isSubmitting}
           defaultValue={folder ? folder.name : ""}
-        ></MuiTextField>
-        <MuiTextField
+          render={({ field, fieldState: { error } }) => (
+            <MuiTextField
+              {...field}
+              label="Folder Name *"
+              variant="outlined"
+              fullWidth
+              error={!!error}
+              helperText={error ? "Please give a name for folder." : null}
+              disabled={isSubmitting}
+            />
+          )}
+          rules={{ required: true, validate: { name: value => value.length > 0 } }}
+        />
+        <Controller
+          control={control}
           name="description"
-          label="Folder Description *"
-          variant="outlined"
-          fullWidth
-          multiline
-          rows={5}
-          inputRef={register({ required: true, validate: { description: value => value.length > 0 } })}
-          helperText={errors.description ? "Please give a description for folder." : null}
-          error={errors.description ? true : false}
-          disabled={isSubmitting}
           defaultValue={folder ? folder.description : ""}
-        ></MuiTextField>
+          render={({ field, fieldState: { error } }) => (
+            <MuiTextField
+              {...field}
+              label="Folder Description *"
+              variant="outlined"
+              fullWidth
+              multiline
+              rows={5}
+              error={!!error}
+              helperText={error ? "Please give a description for folder." : null}
+              disabled={isSubmitting}
+            />
+          )}
+          rules={{ required: true, validate: { description: value => value.length > 0 } }}
+        />
       </form>
       {connError && (
         <WizardStatusMessageHandler successStatus={WizardStatus.error} response={responseError} prefixText="" />

--- a/src/constants/wizardObject.js
+++ b/src/constants/wizardObject.js
@@ -25,3 +25,5 @@ export const ObjectSubmissionsArray = [
   ObjectSubmissionTypes.xml,
   ObjectSubmissionTypes.existing,
 ]
+
+export const OmitObjectValues = ["accessionId", "dateCreated", "dateModified", "publishDate"]

--- a/src/services/draftAPI.js
+++ b/src/services/draftAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
+import { omit } from "lodash"
 
 import { errorMonitor } from "./errorMonitor"
+
+import { OmitObjectValues } from "constants/wizardObject"
 
 const api = create({ baseURL: "/drafts" })
 api.addMonitor(errorMonitor)
@@ -15,7 +18,7 @@ const getObjectByAccessionId = async (objectType: string, accessionId: string): 
 }
 
 const patchFromJSON = async (objectType: string, accessionId: any, JSONContent: any): Promise<any> => {
-  return await api.patch(`/${objectType}/${accessionId}`, JSONContent)
+  return await api.patch(`/${objectType}/${accessionId}`, omit(JSONContent, OmitObjectValues))
 }
 
 const getAllObjectsByObjectType = async (objectType: string): Promise<any> => {

--- a/src/services/objectAPI.js
+++ b/src/services/objectAPI.js
@@ -1,7 +1,10 @@
 //@flow
 import { create } from "apisauce"
+import { omit } from "lodash"
 
 import { errorMonitor } from "./errorMonitor"
+
+import { OmitObjectValues } from "constants/wizardObject"
 
 const api = create({ baseURL: "/objects" })
 api.addMonitor(errorMonitor)
@@ -25,7 +28,7 @@ const getAllObjectsByObjectType = async (objectType: string): Promise<any> => {
 }
 
 const patchFromJSON = async (objectType: string, accessionId: any, JSONContent: any): Promise<any> => {
-  return await api.patch(`/${objectType}/${accessionId}`, JSONContent)
+  return await api.patch(`/${objectType}/${accessionId}`, omit(JSONContent, OmitObjectValues))
 }
 
 const replaceXML = async (objectType: string, accessionId: string, XMLFile: string): Promise<any> => {

--- a/src/views/NewDraftWizard.js
+++ b/src/views/NewDraftWizard.js
@@ -79,7 +79,7 @@ const NewDraftWizard = (): React$Element<typeof Container> => {
   // Fallback if no folder in state
   const folder = useSelector(state => state.submissionFolder)
 
-  if (!folder && (wizardStep === 1 || wizardStep ===2)) {
+  if (!folder && (wizardStep === 1 || wizardStep === 2)) {
     wizardStep = -1
     history.push({ pathname: "/newdraft" })
   }


### PR DESCRIPTION
### Description

React Hook Form migration from V6 to V7 introduced some breaking changes detailed in:
https://react-hook-form.com/migrate-v6-to-v7/

### Related issues

Should fix Dependabot PR #266. Closes #260 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made

 - Update React Hook Form to V7
 - Use `Controller` with Material UI fields in `WizardCreateFolderStep`
 - Register file upload input as described in documentation
 - Render form fields as uncontrolled fields with missing refs
 - Omit patch values so that blocked fields are left out from the request.

### Testing

- Current tests should cover the PR.
