### PR TITLE
Fix the order of api calls when deleting folder

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -44,7 +44,7 @@ describe("Home e2e", function () {
     cy.get("button[type=button]").contains("Save and Exit").click()
     cy.get('button[aria-label="Save a new folder and move to frontpage"]').contains("Return to homepage").click()
 
-    cy.reload()
+    cy.wait(500)
     // Click "See all" button to navigate to all unpublished folders list
     cy.get("div.MuiCardActions-root", { timeout: 60000 })
       .first()

--- a/src/features/wizardSubmissionFolderSlice.js
+++ b/src/features/wizardSubmissionFolderSlice.js
@@ -188,8 +188,6 @@ export const publishFolderContent = (folder: FolderDetailsWithId): (() => Promis
 export const deleteFolderAndContent = (folder: FolderDetailsWithId): (() => Promise<any>) => async () => {
   let message = ""
   if (folder) {
-    const response = await folderAPIService.deleteFolderById(folder.folderId)
-    if (!response.ok) message = `Couldn't delete folder with id ${folder.folderId}`
     if (folder.metadataObjects) {
       await Promise.all(
         folder.metadataObjects.map(async object => {
@@ -198,6 +196,9 @@ export const deleteFolderAndContent = (folder: FolderDetailsWithId): (() => Prom
         })
       )
     }
+
+    const response = await folderAPIService.deleteFolderById(folder.folderId)
+    if (!response.ok) message = `Couldn't delete folder with id ${folder.folderId}`
     return new Promise((resolve, reject) => {
       if (response.ok) {
         resolve(response)


### PR DESCRIPTION
### Description

Deleting a folder no longers shows 404 error in `console`

### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/284

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Deleting `metadataObjects` inside the folder first, then deleting the folder itself

### Testing

- [x] Tests do not apply



