### PR TITLE
Feature/form field tooltips

### DIFF
--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -286,27 +286,27 @@ const FormOneOfField = ({ path, object, nestedField }: { path: string[], object:
         const error = _.get(errors, name)
         return (
           <div>
-              <TextField
-                name={name}
+            <TextField
+              name={name}
               inputProps={{"title": description}}
-                label={label}
-                defaultValue={field}
-                select
-                SelectProps={{ native: true }}
-                onChange={handleChange}
-                error={!!error}
-                helperText={error?.message}
-              >
-                <option aria-label="None" value="" disabled />
-                {options.map(optionObject => {
-                  const option = optionObject.title
-                  return (
-                    <option key={`${name}-${option}`} value={option}>
-                      {option}
-                    </option>
-                  )
-                })}
-              </TextField>
+              label={label}
+              defaultValue={field}
+              select
+              SelectProps={{ native: true }}
+              onChange={handleChange}
+              error={!!error}
+              helperText={error?.message}
+            >
+              <option aria-label="None" value="" disabled />
+              {options.map(optionObject => {
+                const option = optionObject.title
+                return (
+                  <option key={`${name}-${option}`} value={option}>
+                    {option}
+                  </option>
+                )
+              })}
+            </TextField>
             {field ? traverseFields(options.filter(option => option.title === field)[0], path, [], nestedField) : null}
           </div>
         )
@@ -341,20 +341,20 @@ const FormTextField = ({
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
 
       return (
-          <ValidationTextField
-            name={name}
-            inputProps={{ "data-testid": name }, {"title": description}}
-            label={label}
-            role="textbox"
-            inputRef={register}
-            defaultValue={getDefaultValue(nestedField, name)}
-            error={!!error}
-            helperText={error?.message}
-            required={required}
-            type={type}
-            multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
-            rows={5}
-          />
+        <ValidationTextField
+          name={name}
+          inputProps={{ "data-testid": name }, {"title": description}}
+          label={label}
+          role="textbox"
+          inputRef={register}
+          defaultValue={getDefaultValue(nestedField, name)}
+          error={!!error}
+          helperText={error?.message}
+          required={required}
+          type={type}
+          multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
+          rows={5}
+        />
       )
     }}
   </ConnectForm>
@@ -426,7 +426,7 @@ const FormBooleanField = ({ name, label, required, description }: FormFieldBaseP
 /*
  * FormSelectField is rendered for selection from options where it's possible to choose many options
  */
-const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldProps) => (
+const FormCheckBoxArray = ({ name, label, required, options, description }: FormSelectFieldProps  & { description: string}) => (
   <Box px={1}>
     <p>
       <strong>{label}</strong> - check from following options
@@ -440,7 +440,7 @@ const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldPr
               {options.map<React.Element<typeof FormControlLabel>>(option => (
                 <FormControlLabel
                   key={option}
-                  control={<Checkbox name={name} inputRef={register} value={option} color="primary" defaultValue="" />}
+                  control={<Checkbox name={name} inputProps={{"title": description}} inputRef={register} value={option} color="primary" defaultValue="" />}
                   label={option}
                 />
               ))}

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -14,7 +14,6 @@ import IconButton from "@material-ui/core/IconButton"
 import Paper from "@material-ui/core/Paper"
 import { withStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
-import Tooltip from "@material-ui/core/Tooltip"
 import Typography from "@material-ui/core/Typography"
 import AddIcon from "@material-ui/icons/Add"
 import RemoveIcon from "@material-ui/icons/Remove"
@@ -30,12 +29,6 @@ const highlightStyle = theme => {
     borderWidth: 2,
   }
 }
-
-/*
-* To render tooltips of fields conditionally
-*/
-const TooltipWrapper = ({ title, wrapper,  children} ) => 
-  title ? wrapper(children) : children
 
 /*
  * Solve $ref -references in schema, return new schema instead of modifying passed in-place.
@@ -293,9 +286,9 @@ const FormOneOfField = ({ path, object, nestedField }: { path: string[], object:
         const error = _.get(errors, name)
         return (
           <div>
-            <TooltipWrapper title={description} wrapper={(children) => <Tooltip title={description} placement="top">{children}</Tooltip>} >
               <TextField
                 name={name}
+              inputProps={{"title": description}}
                 label={label}
                 defaultValue={field}
                 select
@@ -314,7 +307,6 @@ const FormOneOfField = ({ path, object, nestedField }: { path: string[], object:
                   )
                 })}
               </TextField>
-            </TooltipWrapper>
             {field ? traverseFields(options.filter(option => option.title === field)[0], path, [], nestedField) : null}
           </div>
         )
@@ -349,10 +341,9 @@ const FormTextField = ({
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
 
       return (
-        <TooltipWrapper title={description} wrapper={(children) => <Tooltip title={description} placement="top">{children}</Tooltip>} >
           <ValidationTextField
             name={name}
-            inputProps={{ "data-testid": name }}
+            inputProps={{ "data-testid": name }, {"title": description}}
             label={label}
             role="textbox"
             inputRef={register}
@@ -364,7 +355,6 @@ const FormTextField = ({
             multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
             rows={5}
           />
-        </TooltipWrapper>
       )
     }}
   </ConnectForm>
@@ -387,9 +377,9 @@ const FormSelectField = ({ name, label, required, description, options, nestedFi
     {({ register, errors }) => {
       const error = _.get(errors, name)
       return (
-        <TooltipWrapper title={description} wrapper={(children) => <Tooltip title={description} placement="top">{children}</Tooltip>} >
         <ValidationSelectField
           name={name}
+          inputProps={{"title": description}}
           label={label}
           inputRef={register}
           defaultValue={getDefaultValue(nestedField, name)}
@@ -406,7 +396,6 @@ const FormSelectField = ({ name, label, required, description, options, nestedFi
             </option>
           ))}
         </ValidationSelectField>
-        </TooltipWrapper>
       )
     }}
   </ConnectForm>
@@ -421,16 +410,14 @@ const FormBooleanField = ({ name, label, required, description }: FormFieldBaseP
         console.log("FormBoolean")
       const error = _.get(errors, name)
       return (
-        <TooltipWrapper title={description} wrapper={(children) => <Tooltip title={description} placement="top">{children}</Tooltip>} >
         <Box display="inline" px={1}>
           <FormControl error={!!error} required={required}>
             <FormGroup>
-              <FormControlLabel control={<Checkbox name={name} inputRef={register} defaultValue="" />} label={label} />
+              <FormControlLabel control={<Checkbox name={name} inputProps={{"title": description}} inputRef={register} defaultValue="" />} label={label} />
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
           </FormControl>
         </Box>
-        </TooltipWrapper>
       )
     }}
   </ConnectForm>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -401,7 +401,7 @@ const FormSelectField = ({ name, label, required, description, options, nestedFi
   </ConnectForm>
 )
 
-/* !!! Analysis Sequence Variantion imputation checkbox does not have description
+/*
  * FormSelectField is rendered for checkboxes
  */
 const FormBooleanField = ({ name, label, required, description }: FormFieldBaseProps  & { description: string}) => (

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -343,7 +343,7 @@ const FormTextField = ({
       return (
         <ValidationTextField
           name={name}
-          inputProps={{ "data-testid": name }, {"title": description}}
+          inputProps={{ "data-testid": name, "title": description}}
           label={label}
           role="textbox"
           inputRef={register}


### PR DESCRIPTION
### Description

A new feature to add description of fields to show as tooltips. Implemented by transferring the description of the field to title of the field. This is done by following the existing parsing of the forms fields from ENA schema.

### Related issues

Fixes https://github.com/CSCfi/metadata-submitter-frontend/issues/172

### Type of change

<!-- Replace [ ] with [x] to select options. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
Added description to the title of fields.

### Testing
This will need testing that if description exist it is rendered when hovering?
<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions
Now this fails in a unit test WizardFillObjectDetailsForm.test.js with `Unable to find an element by: [data-testid="descriptor.studyTitle"]`
