### PR TITLE
Reset object in state when editing submitted item

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -36,6 +36,9 @@ describe("Basic e2e", function () {
     cy.get("button[type=submit]").contains("Submit").click()
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
+    // Clear form
+    cy.get("button[type=button]").contains("Clear").click()
+
     // Edit saved submission
     cy.get("button[type=button]").contains("Edit").click()
     cy.get("input[name='descriptor.studyTitle']").should("have.value", "New title")

--- a/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectActions.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardSavedObjectActions.js
@@ -45,6 +45,7 @@ const WizardSavedObjectActions = (props: WizardSavedObjectActionsProps): React$E
     const response = await objectAPIService.getObjectByAccessionId(props.objectType, props.objectId)
 
     if (response.ok) {
+      dispatch(resetCurrentObject())
       dispatch(
         setCurrentObject({
           ...response.data,

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -230,7 +230,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
     methods.reset({})
     setCleanedValues({})
     dispatch(resetDraftStatus())
-    dispatch(resetCurrentObject())
   }
 
   // Check if the form is empty

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -230,6 +230,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
     methods.reset({})
     setCleanedValues({})
     dispatch(resetDraftStatus())
+    dispatch(resetCurrentObject())
   }
 
   // Check if the form is empty


### PR DESCRIPTION
### Description

Form didn't populate when trying to edit submitted item after user has cleared the form.

### Related issues

Closes #292 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Dispatch `resetCurrentObject` method when clearing form

### Testing

- [x] E2E
