### PR TITLE
Bugfix/dac main contact

### DIFF
--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -213,6 +213,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
     setCleanedValues(currentObject)
   }, [currentObject?.accessionId])
 
+  console.log("formSchema :>> ", formSchema)
   // Check if form has been edited
   useEffect(() => {
     checkDirty()

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -118,15 +118,8 @@ type FormContentProps = {
  */
 const CustomCardHeader = (props: CustomCardHeaderProps) => {
   const classes = useStyles()
-  const {
-    objectType,
-    currentObject,
-    refForm,
-    onClickNewForm,
-    onClickClearForm,
-    onClickSaveDraft,
-    onClickSubmit,
-  } = props
+  const { objectType, currentObject, refForm, onClickNewForm, onClickClearForm, onClickSaveDraft, onClickSubmit } =
+    props
 
   const dispatch = useDispatch()
 
@@ -213,7 +206,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
     setCleanedValues(currentObject)
   }, [currentObject?.accessionId])
 
-  console.log("formSchema :>> ", formSchema)
   // Check if form has been edited
   useEffect(() => {
     checkDirty()

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -621,7 +621,8 @@ const FormArray = ({ object, path, required }: FormArrayProps) => {
         }
 
         const properties = object.items.properties
-        const requiredProperties = index === 0 ? object.contains?.allOf?.flatMap(item => item.required) : []
+        const requiredProperties =
+          index === 0 ? object.contains?.allOf?.flatMap(item => item.required) : object.items?.required
 
         return (
           <div className="arrayRow" key={`${name}[${index}]`}>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -507,17 +507,25 @@ const ValidationFormControlLabel = withStyles(theme => ({
  */
 const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
   <ConnectForm>
-    {({ register, errors }) => {
+    {({ register, errors, getValues }) => {
       const error = _.get(errors, name)
       const { ref, ...rest } = register(name)
-
+      // DAC form: "values" of MainContact checkbox
+      const values = getValues(name)
       return (
         <Box display="inline" px={1}>
           <FormControl error={!!error} required={required}>
             <FormGroup>
               <ValidationFormControlLabel
                 control={
-                  <Checkbox name={name} {...rest} required={required} inputRef={ref} color="primary" defaultValue="" />
+                  <Checkbox
+                    name={name}
+                    {...rest}
+                    required={required}
+                    inputRef={ref}
+                    color="primary"
+                    checked={values || false}
+                  />
                 }
                 label={
                   <label>
@@ -611,8 +619,9 @@ const FormArray = ({ object, path, required }: FormArrayProps) => {
             </div>
           )
         }
+
         const properties = object.items.properties
-        const requiredProperties = object.contains?.allOf?.flatMap(item => item.required)
+        const requiredProperties = index === 0 ? object.contains?.allOf?.flatMap(item => item.required) : []
 
         return (
           <div className="arrayRow" key={`${name}[${index}]`}>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -494,6 +494,15 @@ const FormSelectField = ({ name, label, required, options, nestedField }: FormSe
 )
 
 /*
+ * Highlight required Checkbox
+ */
+const ValidationFormControlLabel = withStyles(theme => ({
+  label: {
+    "& span": { color: theme.palette.primary.main },
+  },
+}))(FormControlLabel)
+
+/*
  * FormSelectField is rendered for checkboxes
  */
 const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
@@ -506,9 +515,16 @@ const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
         <Box display="inline" px={1}>
           <FormControl error={!!error} required={required}>
             <FormGroup>
-              <FormControlLabel
-                control={<Checkbox name={name} {...rest} inputRef={ref} defaultValue="" />}
-                label={label}
+              <ValidationFormControlLabel
+                control={
+                  <Checkbox name={name} {...rest} required={required} inputRef={ref} color="primary" defaultValue="" />
+                }
+                label={
+                  <label>
+                    {label}
+                    <span>{required ? ` * ` : ""}</span>
+                  </label>
+                }
               />
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
@@ -580,6 +596,7 @@ const FormArray = ({ object, path, required }: FormArrayProps) => {
         const [lastPathItem] = path.slice(-1)
         const pathWithoutLastItem = path.slice(0, -1)
         const lastPathItemWithIndex = `${lastPathItem}[${index}]`
+
         if (items.oneOf) {
           const pathForThisIndex = [...pathWithoutLastItem, lastPathItemWithIndex]
 
@@ -595,13 +612,15 @@ const FormArray = ({ object, path, required }: FormArrayProps) => {
           )
         }
         const properties = object.items.properties
+        const requiredProperties = object.contains?.allOf?.flatMap(item => item.required)
 
         return (
           <div className="arrayRow" key={`${name}[${index}]`}>
             <Paper elevation={2}>
               {Object.keys(items).map(item => {
                 const pathForThisIndex = [...pathWithoutLastItem, lastPathItemWithIndex, item]
-                return traverseFields(properties[item], pathForThisIndex, [], false, field)
+                const requiredField = requiredProperties ? requiredProperties.filter(prop => prop === item) : []
+                return traverseFields(properties[item], pathForThisIndex, requiredField, false, field)
               })}
             </Paper>
             <IconButton onClick={() => remove(index)}>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,7 +10,7 @@ export const getObjectDisplayTitle = (objectType: string, cleanedValues: any): s
     case ObjectTypes.study:
       return cleanedValues.descriptor?.studyTitle || ""
     case ObjectTypes.dac:
-      return cleanedValues.contacts?.find(contact => contact.mainContact).name || ""
+      return cleanedValues.contacts?.find(contact => contact.mainContact)?.name || ""
     default:
       return cleanedValues.title || ""
   }


### PR DESCRIPTION
### Description

In DAC form, the `Main Contact ` checkbox is highlighted with `*` so that the user knows it's mandatory to have the Main Contact before submitting the form.

### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/331

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Add `*` to `Main Contact` label and make the checkbox as required when submitting DAC form
- Fix to render the checkbox correctly as **checked/unchecked** when editing the DAC form

### Testing

- [x] Tests do not apply
