### PR TITLE
Feature/form field tooltips

### DIFF
--- a/cypress/integration/editForm.spec.js
+++ b/cypress/integration/editForm.spec.js
@@ -90,7 +90,7 @@ describe("Populate form and render form elements by object data", function () {
 
     // Switch to select and fill Complex processing
     cy.get("select[name='processing']").select(testData.complexProcessing)
-    cy.get(":nth-child(7) > .array > .MuiButtonBase-root > .MuiButton-label").click()
+    cy.get("h2[data-testid='processing']").parent().children("button").click()
     cy.get(".MuiPaper-root > :nth-child(1) > .formSection > .array > .MuiButtonBase-root > .MuiButton-label").click()
     cy.get("input[data-testid='processing[0].pipeline.pipeSection[0].stepIndex']").type(testData.stepIndex)
     cy.get("select[name='processing[0].pipeline.pipeSection[0].prevStepIndex']").select(testData.stringValue)
@@ -137,7 +137,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("button[aria-label='Continue draft']").first().click()
 
     // Test that Prev Step Index is nulled
-    cy.get("input[data-testid='processing[0].pipeline.pipeSection[0].stepIndex']").should("not.exist")
+    cy.get("input[data-testid='processing[0].pipeline.pipeSection[0].prevStepIndex']").should("not.exist")
   })
 
   it("should render Run form correctly when editing", () => {

--- a/cypress/integration/linkingAccessionIds.spec.js
+++ b/cypress/integration/linkingAccessionIds.spec.js
@@ -98,8 +98,7 @@ describe("Linking Accession Ids", function () {
 
     // Run form
     cy.get("div[role=button]").contains("Run").click()
-    cy.wait(500)
-    cy.get("div[aria-expanded='true']")
+    cy.get("div[aria-expanded='true']", { timeout: 10000 })
       .siblings()
       .within(() =>
         cy
@@ -108,7 +107,7 @@ describe("Linking Accession Ids", function () {
           .should("be.visible")
           .then($btn => $btn.click())
       )
-    cy.get("div").contains("Experiment Reference").parent().children("button").click()
+    cy.get("h2[data-testid='experimentRef']").parent().children("button").click()
     cy.get("[data-testid='experimentRef[0].label']").type("Test experiment label ref")
     // Select experimentAccessionId
     cy.get("select[name='experimentRef[0].accessionId']").then($el => {
@@ -202,7 +201,7 @@ describe("Linking Accession Ids", function () {
           .then($btn => $btn.click())
       )
 
-    cy.get("div").contains("Contacts").parent().children("button").click()
+    cy.get("h2[data-testid='contacts']").parent().children("button").click()
     cy.get("input[name='contacts[0].name']").type("Test contact name")
     cy.get("input[name='contacts[0].email']").type("contact@hotmail.com")
     cy.get("input[name='contacts[0].telephoneNumber']").type("Test phone number")

--- a/src/__tests__/WizardFillObjectDetailsForm.test.js
+++ b/src/__tests__/WizardFillObjectDetailsForm.test.js
@@ -84,6 +84,24 @@ describe("WizardFillObjectDetailsForm", () => {
     })
   })
 
+  it("should show tooltip on mouse over", async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={CSCtheme}>
+          <WizardFillObjectDetailsForm />
+        </ThemeProvider>
+      </Provider>
+    )
+    await waitFor(() => {
+      const tooltip = screen.getByTitle("Title of the study as would be used in a publication.")
+      fireEvent.mouseOver(tooltip)
+      expect(tooltip).toBeVisible()
+    }
+    )
+  }
+
+  )
+
   // Note: If this test runs before form creation, form creation fails because getItem spy messes sessionStorage init somehow
   it("should call sessionStorage", async () => {
     const spy = jest.spyOn(Storage.prototype, "getItem")

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -39,6 +39,11 @@ const helpIconStyle = makeStyles(theme => ({
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
   },
+  divBaseline: {
+    display: 'flex',
+    alignItems: 'baseline',
+    flexWrap: 'wrap',
+  }
 }))
 
 const FieldTooltip = withStyles(theme => ({
@@ -495,34 +500,36 @@ const FormOneOfField = ({
 
         return (
           <div>
-            <ValidationSelectField
-              name={name}
-              label={label}
-              defaultValue={field}
-              select
-              SelectProps={{ native: true }}
-              onChange={event => {
-                handleChange(event)
-              }}
-              error={!!error}
-              helperText={error?.message}
-              required={required}
-            >
-              <option aria-label="None" value="" disabled />
-              {options?.map(optionObject => {
-                const option = optionObject.title
-                return (
-                  <option key={`${name}-${option}`} value={option}>
-                    {option}
-                  </option>
-                )
-              })}
-            </ValidationSelectField>
-            {description && (
-              <FieldTooltip title={description} placement="bottom" arrow>
-                <HelpOutlineIcon className={classes.fieldTip} />
-              </FieldTooltip>
-            )}
+            <div className={classes.divBaseline}>
+              <ValidationSelectField
+                name={name}
+                label={label}
+                defaultValue={field}
+                select
+                SelectProps={{ native: true }}
+                onChange={event => {
+                  handleChange(event)
+                }}
+                error={!!error}
+                helperText={error?.message}
+                required={required}
+              >
+                <option aria-label="None" value="" disabled />
+                {options?.map(optionObject => {
+                  const option = optionObject.title
+                  return (
+                    <option key={`${name}-${option}`} value={option}>
+                      {option}
+                    </option>
+                  )
+                })}
+              </ValidationSelectField>
+              {description && (
+                <FieldTooltip title={description} placement="top" arrow>
+                  <HelpOutlineIcon className={classes.fieldTip} />
+                </FieldTooltip>
+              )}
+            </div>
             {field
               ? traverseFields(
                   options?.filter(option => option.title === field)[0],
@@ -564,27 +571,33 @@ const FormTextField = ({
       const classes = helpIconStyle()
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
       return (
-        <>
           <Controller
             render={({ field, fieldState: { error } }) => {
               return (
-                <ValidationTextField
-                  {...field}
-                  inputProps={{ "data-testid": name }}
-                  label={label}
-                  role="textbox"
-                  error={!!error}
-                  helperText={error?.message}
-                  required={required}
-                  type={type}
-                  multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
-                  rows={5}
-                  value={(typeof field.value !== "object" && field.value) || ""}
-                  onChange={e => {
-                    const val = e.target.value
-                    field.onChange(type === "string" && !isNaN(val) ? val.toString() : val)
-                  }}
-                />
+                <div className={classes.divBaseline} >
+                  <ValidationTextField
+                    {...field}
+                    inputProps={{ "data-testid": name }}
+                    label={label}
+                    role="textbox"
+                    error={!!error}
+                    helperText={error?.message}
+                    required={required}
+                    type={type}
+                    multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
+                    rows={5}
+                    value={(typeof field.value !== "object" && field.value) || ""}
+                    onChange={e => {
+                      const val = e.target.value
+                      field.onChange(type === "string" && !isNaN(val) ? val.toString() : val)
+                    }}
+                  />
+                  {description && (
+                    <FieldTooltip title={description} placement="top" arrow>
+                      <HelpOutlineIcon className={classes.fieldTip} />
+                    </FieldTooltip>
+                  )}
+                </div>
               )
             }}
             name={name}
@@ -592,12 +605,6 @@ const FormTextField = ({
             defaultValue={getDefaultValue(nestedField, name)}
             rules={{ required: required }}
           />
-          {description && (
-            <FieldTooltip title={description} placement="bottom" arrow>
-              <HelpOutlineIcon className={classes.fieldTip} />
-            </FieldTooltip>
-          )}
-        </>
       )
     }}
   </ConnectForm>
@@ -620,7 +627,7 @@ const FormSelectField = ({
       const { ref, ...rest } = register(name)
 
       return (
-        <>
+        <div className={classes.divBaseline}>
           <ValidationSelectField
             name={name}
             label={label}
@@ -641,11 +648,11 @@ const FormSelectField = ({
             ))}
           </ValidationSelectField>
           {description && (
-            <FieldTooltip title={description} placement="bottom" arrow>
+            <FieldTooltip title={description} placement="top" arrow>
               <HelpOutlineIcon className={classes.fieldTip} />
             </FieldTooltip>
           )}
-        </>
+        </div>
       )
     }}
   </ConnectForm>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -42,7 +42,6 @@ const helpIconStyle = makeStyles(theme => ({
   divBaseline: {
     display: 'flex',
     alignItems: 'baseline',
-    flexWrap: 'wrap',
   }
 }))
 

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -38,7 +38,7 @@ const helpIconStyle = makeStyles(theme => ({
   fieldTip: {
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
-  }
+  },
 }))
 
 const FieldTooltip = withStyles(theme => ({
@@ -218,7 +218,14 @@ const traverseFields = (
     }
     case "string": {
       return object["enum"] ? (
-        <FormSelectField key={name} name={name} label={label} options={object.enum} required={required} />
+        <FormSelectField
+          key={name}
+          name={name}
+          label={label}
+          options={object.enum}
+          required={required}
+          description={description}
+        />
       ) : (
         <FormTextField
           key={name}
@@ -228,18 +235,12 @@ const traverseFields = (
           description={description}
           nestedField={nestedField}
         />
-<<<<<<< HEAD
-=======
-      ) : (
-        <FormTextField key={name} name={name} label={label} required={required} description={description} nestedField={nestedField} />
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
       )
     }
     case "integer": {
       return <FormTextField key={name} name={name} label={label} required={required} description={description} />
     }
     case "number": {
-<<<<<<< HEAD
       return (
         <FormTextField
           key={name}
@@ -250,16 +251,12 @@ const traverseFields = (
           type="number"
         />
       )
-=======
-      return <FormTextField key={name} name={name} label={label} required={required} description={description} type="number" />
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
     }
     case "boolean": {
       return <FormBooleanField key={name} name={name} label={label} required={required} description={description} />
     }
     case "array": {
       return object.items.enum ? (
-<<<<<<< HEAD
         <FormCheckBoxArray
           key={name}
           name={name}
@@ -268,9 +265,6 @@ const traverseFields = (
           required={required}
           description={description}
         />
-=======
-        <FormCheckBoxArray key={name} name={name} label={label} options={object.items.enum} required={required} description={description} />
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
       ) : (
         <FormArray key={name} object={object} path={path} required={required} description={description} />
       )
@@ -366,10 +360,6 @@ const FormOneOfField = ({
   const options = object.oneOf
   const [lastPathItem] = path.slice(-1)
   const description = object.description
-<<<<<<< HEAD
-=======
-
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
   // Get the fieldValue when rendering a saved/submitted form
   // For e.g. obj.required is ["label", "url"] and nestedField is {id: "sth1", label: "sth2", url: "sth3"}
   // Get object from state and set default values if child of oneOf field has values
@@ -472,7 +462,6 @@ const FormOneOfField = ({
     <ConnectForm>
       {({ errors, unregister }) => {
         const error = _.get(errors, name)
-<<<<<<< HEAD
         // Option change handling
         const [field, setField] = useState(fieldValue)
         const handleChange = event => {
@@ -482,10 +471,6 @@ const FormOneOfField = ({
           if (val === "Complex Processing" || val === "Null value") unregister(name)
         }
         const classes = helpIconStyle()
-=======
-        const classes = helpIconStyle()
-
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
         // Selected option
         const selectedOption = options?.filter(option => option.title === field)[0]?.properties || {}
         const selectedOptionValues = Object.values(selectedOption)
@@ -510,7 +495,6 @@ const FormOneOfField = ({
 
         return (
           <div>
-<<<<<<< HEAD
             <ValidationSelectField
               name={name}
               label={label}
@@ -539,34 +523,6 @@ const FormOneOfField = ({
                 <HelpOutlineIcon className={classes.fieldTip} />
               </FieldTooltip>
             )}
-=======
-              <ValidationSelectField
-                name={name}
-                label={label}
-                defaultValue={field}
-                select
-                SelectProps={{ native: true }}
-                onChange={event => {
-                  handleChange(event)
-                  // Unregister if nullable field
-                  if (event.target.value === "Null value") unregister(name)
-                }}
-                error={!!error}
-                helperText={error?.message}
-                required={required}
-              >
-                <option aria-label="None" value="" disabled />
-                {options?.map(optionObject => {
-                  const option = optionObject.title
-                  return (
-                    <option key={`${name}-${option}`} value={option}>
-                      {option}
-                    </option>
-                  )
-                })}
-              </ValidationSelectField>
-              {description && <FieldTooltip title={description} placement="bottom" arrow><HelpOutlineIcon className={classes.fieldTip } /></FieldTooltip>}
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
             {field
               ? traverseFields(
                   options?.filter(option => option.title === field)[0],
@@ -608,17 +564,10 @@ const FormTextField = ({
       const classes = helpIconStyle()
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
       return (
-<<<<<<< HEAD
         <>
           <Controller
             render={({ field, fieldState: { error } }) => {
               return (
-=======
-        <Controller
-            render={({ field, fieldState: { error } }) => {
-            return (
-              <div>
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
                 <ValidationTextField
                   {...field}
                   inputProps={{ "data-testid": name }}
@@ -630,17 +579,12 @@ const FormTextField = ({
                   type={type}
                   multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
                   rows={5}
-<<<<<<< HEAD
                   value={(typeof field.value !== "object" && field.value) || ""}
-=======
-                  value={field.value || ""}
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
                   onChange={e => {
                     const val = e.target.value
                     field.onChange(type === "string" && !isNaN(val) ? val.toString() : val)
                   }}
                 />
-<<<<<<< HEAD
               )
             }}
             name={name}
@@ -654,17 +598,6 @@ const FormTextField = ({
             </FieldTooltip>
           )}
         </>
-=======
-                {description && <FieldTooltip title={description} placement="bottom" arrow><HelpOutlineIcon className={classes.fieldTip } /></FieldTooltip>}
-              </div>
-            )
-          }}
-          name={name}
-          control={control}
-          defaultValue={getDefaultValue(nestedField, name)}
-          rules={{ required: required }}
-         />
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
       )
     }}
   </ConnectForm>
@@ -673,7 +606,6 @@ const FormTextField = ({
 /*
  * FormSelectField is rendered for choosing one from many options
  */
-<<<<<<< HEAD
 const FormSelectField = ({
   name,
   label,
@@ -681,9 +613,6 @@ const FormSelectField = ({
   options,
   description,
 }: FormSelectFieldProps & { description: string }) => (
-=======
-const FormSelectField = ({ name, label, required, options, nestedField, description }: FormSelectFieldProps & {description: string}) => (
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
@@ -691,21 +620,13 @@ const FormSelectField = ({ name, label, required, options, nestedField, descript
       const { ref, ...rest } = register(name)
 
       return (
-<<<<<<< HEAD
         <>
-=======
-        <div>
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
           <ValidationSelectField
             name={name}
             label={label}
             {...rest}
             inputRef={ref}
-<<<<<<< HEAD
             defaultValue=""
-=======
-            defaultValue={getDefaultValue(nestedField, name)}
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
             error={!!error}
             helperText={error?.message}
             required={required}
@@ -719,18 +640,12 @@ const FormSelectField = ({ name, label, required, options, nestedField, descript
               </option>
             ))}
           </ValidationSelectField>
-<<<<<<< HEAD
           {description && (
             <FieldTooltip title={description} placement="bottom" arrow>
               <HelpOutlineIcon className={classes.fieldTip} />
             </FieldTooltip>
           )}
         </>
-=======
-          
-          {description && <FieldTooltip title={description} placement="bottom" arrow><HelpOutlineIcon className={classes.fieldTip } /></FieldTooltip>}
-        </div>
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
       )
     }}
   </ConnectForm>
@@ -748,11 +663,7 @@ const ValidationFormControlLabel = withStyles(theme => ({
 /*
  * FormSelectField is rendered for checkboxes
  */
-<<<<<<< HEAD
 const FormBooleanField = ({ name, label, required, description }: FormFieldBaseProps & { description: string }) => (
-=======
-const FormBooleanField = ({ name, label, required,description }: FormFieldBaseProps & {description: string}) => (
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
   <ConnectForm>
     {({ register, errors, getValues }) => {
       const error = _.get(errors, name)
@@ -782,15 +693,11 @@ const FormBooleanField = ({ name, label, required,description }: FormFieldBasePr
                   </label>
                 }
               />
-<<<<<<< HEAD
               {description && (
                 <FieldTooltip title={description} placement="bottom" arrow>
                   <HelpOutlineIcon className={classes.fieldTip} />
                 </FieldTooltip>
               )}
-=======
-              {description && <FieldTooltip title={description} placement="bottom" arrow><HelpOutlineIcon className={classes.fieldTip } /></FieldTooltip>}
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
           </FormControl>
@@ -803,7 +710,6 @@ const FormBooleanField = ({ name, label, required,description }: FormFieldBasePr
 /*
  * FormSelectField is rendered for selection from options where it's possible to choose many options
  */
-<<<<<<< HEAD
 const FormCheckBoxArray = ({
   name,
   label,
@@ -811,9 +717,6 @@ const FormCheckBoxArray = ({
   options,
   description,
 }: FormSelectFieldProps & { description: string }) => (
-=======
-const FormCheckBoxArray = ({ name, label, required, options ,description }: FormSelectFieldProps & {description: string}) => (
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
   <Box px={1}>
     <p>
       <strong>{label}</strong> - check from following options
@@ -830,7 +733,6 @@ const FormCheckBoxArray = ({ name, label, required, options ,description }: Form
           <FormControl error={!!error} required={required}>
             <FormGroup>
               {options.map<React.Element<typeof FormControlLabel>>(option => (
-<<<<<<< HEAD
                 <React.Fragment key={option}>
                   <FormControlLabel
                     key={option}
@@ -853,26 +755,6 @@ const FormCheckBoxArray = ({ name, label, required, options ,description }: Form
                     </FieldTooltip>
                   )}
                 </React.Fragment>
-=======
-                <div key={option}>
-                  <FormControlLabel
-                    
-                    control={
-                      <Checkbox
-                      name={name}
-                      {...rest}
-                      inputRef={ref}
-                      value={option}
-                      checked={values && values?.includes(option) ? true : false}
-                      color="primary"
-                      defaultValue=""
-                    />
-                    }
-                    label={option}
-                  />
-                  {description && <FieldTooltip title={description} placement="bottom" arrow><HelpOutlineIcon className={classes.fieldTip } /></FieldTooltip>}
-                </div>
->>>>>>> 0439f15f37de3d54ace09530064b57fe27da0d75
               ))}
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
@@ -919,7 +801,7 @@ const FormArray = ({ object, path, required }: FormArrayProps) => {
 
   return (
     <div className="array" key={`${name}-array`}>
-      <Typography key={`${name}-header`} variant={`h${level}`}>
+      <Typography key={`${name}-header`} variant={`h${level}`} data-testid={name}>
         {label} {required ? "*" : null}
       </Typography>
       {fields.map((field, index) => {

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -36,9 +36,10 @@ const highlightStyle = theme => {
 
 const helpIconStyle = makeStyles(theme => ({
   fieldTip: {
+    bordercolor: "#FF00000",
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
-  },
+  }
 }))
 
 const FieldTooltip = withStyles(theme => ({

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -36,7 +36,6 @@ const highlightStyle = theme => {
 
 const helpIconStyle = makeStyles(theme => ({
   fieldTip: {
-    bordercolor: "#FF00000",
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
   }

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -36,7 +36,6 @@ const highlightStyle = theme => {
 
 const helpIconStyle = makeStyles(theme => ({
   fieldTip: {
-    bordercolor: "#FF00000",
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
   },

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -12,10 +12,12 @@ import FormGroup from "@material-ui/core/FormGroup"
 import FormHelperText from "@material-ui/core/FormHelperText"
 import IconButton from "@material-ui/core/IconButton"
 import Paper from "@material-ui/core/Paper"
-import { withStyles } from "@material-ui/core/styles"
+import { makeStyles, withStyles } from "@material-ui/core/styles"
 import TextField from "@material-ui/core/TextField"
+import Tooltip from "@material-ui/core/Tooltip"
 import Typography from "@material-ui/core/Typography"
 import AddIcon from "@material-ui/icons/Add"
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline"
 import RemoveIcon from "@material-ui/icons/Remove"
 import * as _ from "lodash"
 import { get } from "lodash"
@@ -31,6 +33,23 @@ const highlightStyle = theme => {
     borderWidth: 2,
   }
 }
+
+const helpIconStyle = makeStyles(theme => ({
+  fieldTip: {
+    bordercolor: "#FF00000",
+    color: theme.palette.secondary.main,
+    marginLeft: theme.spacing(0),
+  },
+}))
+
+const FieldTooltip = withStyles(theme => ({
+  tooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: theme.palette.common.black,
+    fontSize: theme.typography.pxToRem(14),
+    boxShadow: theme.shadows[1],
+  },
+}))(Tooltip)
 
 /*
  * Solve $ref -references in schema, return new schema instead of modifying passed in-place.
@@ -170,6 +189,7 @@ const traverseFields = (
   const [lastPathItem] = path.slice(-1)
   const label = object.title ?? lastPathItem
   const required = !!requiredProperties?.includes(lastPathItem) || requireFirst || false
+  const description = object.description
 
   if (object.oneOf) return <FormOneOfField key={name} path={path} object={object} required={required} />
 
@@ -201,23 +221,46 @@ const traverseFields = (
       return object["enum"] ? (
         <FormSelectField key={name} name={name} label={label} options={object.enum} required={required} />
       ) : (
-        <FormTextField key={name} name={name} label={label} required={required} nestedField={nestedField} />
+        <FormTextField
+          key={name}
+          name={name}
+          label={label}
+          required={required}
+          description={description}
+          nestedField={nestedField}
+        />
       )
     }
     case "integer": {
-      return <FormTextField key={name} name={name} label={label} required={required} />
+      return <FormTextField key={name} name={name} label={label} required={required} description={description} />
     }
     case "number": {
-      return <FormTextField key={name} name={name} label={label} required={required} type="number" />
+      return (
+        <FormTextField
+          key={name}
+          name={name}
+          label={label}
+          required={required}
+          description={description}
+          type="number"
+        />
+      )
     }
     case "boolean": {
-      return <FormBooleanField key={name} name={name} label={label} required={required} />
+      return <FormBooleanField key={name} name={name} label={label} required={required} description={description} />
     }
     case "array": {
       return object.items.enum ? (
-        <FormCheckBoxArray key={name} name={name} label={label} options={object.items.enum} required={required} />
+        <FormCheckBoxArray
+          key={name}
+          name={name}
+          label={label}
+          options={object.items.enum}
+          required={required}
+          description={description}
+        />
       ) : (
-        <FormArray key={name} object={object} path={path} required={required} />
+        <FormArray key={name} object={object} path={path} required={required} description={description} />
       )
     }
     case "null": {
@@ -310,7 +353,7 @@ const FormOneOfField = ({
 }) => {
   const options = object.oneOf
   const [lastPathItem] = path.slice(-1)
-
+  const description = object.description
   // Get the fieldValue when rendering a saved/submitted form
   // For e.g. obj.required is ["label", "url"] and nestedField is {id: "sth1", label: "sth2", url: "sth3"}
   // Get object from state and set default values if child of oneOf field has values
@@ -421,6 +464,7 @@ const FormOneOfField = ({
           // Unregister if selecting "Complex Processing", "Null value" in Experiment form
           if (val === "Complex Processing" || val === "Null value") unregister(name)
         }
+        const classes = helpIconStyle()
         // Selected option
         const selectedOption = options?.filter(option => option.title === field)[0]?.properties || {}
         const selectedOptionValues = Object.values(selectedOption)
@@ -468,6 +512,11 @@ const FormOneOfField = ({
                 )
               })}
             </ValidationSelectField>
+            {description && (
+              <FieldTooltip title={description} placement="bottom" arrow>
+                <HelpOutlineIcon className={classes.fieldTip} />
+              </FieldTooltip>
+            )}
             {field
               ? traverseFields(
                   options?.filter(option => option.title === field)[0],
@@ -500,40 +549,49 @@ const FormTextField = ({
   name,
   label,
   required,
+  description,
   type = "string",
   nestedField,
-}: FormFieldBaseProps & { type?: string, nestedField?: any }) => (
+}: FormFieldBaseProps & { description: string, type?: string, nestedField?: any }) => (
   <ConnectForm>
     {({ control }) => {
+      const classes = helpIconStyle()
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
       return (
-        <Controller
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <ValidationTextField
-                {...field}
-                inputProps={{ "data-testid": name }}
-                label={label}
-                role="textbox"
-                error={!!error}
-                helperText={error?.message}
-                required={required}
-                type={type}
-                multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
-                rows={5}
-                value={(typeof field.value !== "object" && field.value) || ""}
-                onChange={e => {
-                  const val = e.target.value
-                  field.onChange(type === "string" && !isNaN(val) ? val.toString() : val)
-                }}
-              />
-            )
-          }}
-          name={name}
-          control={control}
-          defaultValue={getDefaultValue(nestedField, name)}
-          rules={{ required: required }}
-        />
+        <>
+          <Controller
+            render={({ field, fieldState: { error } }) => {
+              return (
+                <ValidationTextField
+                  {...field}
+                  inputProps={{ "data-testid": name }}
+                  label={label}
+                  role="textbox"
+                  error={!!error}
+                  helperText={error?.message}
+                  required={required}
+                  type={type}
+                  multiline={multiLineRowIdentifiers.some(value => label.toLowerCase().includes(value))}
+                  rows={5}
+                  value={(typeof field.value !== "object" && field.value) || ""}
+                  onChange={e => {
+                    const val = e.target.value
+                    field.onChange(type === "string" && !isNaN(val) ? val.toString() : val)
+                  }}
+                />
+              )
+            }}
+            name={name}
+            control={control}
+            defaultValue={getDefaultValue(nestedField, name)}
+            rules={{ required: required }}
+          />
+          {description && (
+            <FieldTooltip title={description} placement="bottom" arrow>
+              <HelpOutlineIcon className={classes.fieldTip} />
+            </FieldTooltip>
+          )}
+        </>
       )
     }}
   </ConnectForm>
@@ -542,32 +600,46 @@ const FormTextField = ({
 /*
  * FormSelectField is rendered for choosing one from many options
  */
-const FormSelectField = ({ name, label, required, options }: FormSelectFieldProps) => (
+const FormSelectField = ({
+  name,
+  label,
+  required,
+  options,
+  description,
+}: FormSelectFieldProps & { description: string }) => (
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
+      const classes = helpIconStyle()
       const { ref, ...rest } = register(name)
 
       return (
-        <ValidationSelectField
-          name={name}
-          label={label}
-          {...rest}
-          inputRef={ref}
-          defaultValue=""
-          error={!!error}
-          helperText={error?.message}
-          required={required}
-          select
-          SelectProps={{ native: true }}
-        >
-          <option aria-label="None" value="" disabled />
-          {options.map(option => (
-            <option key={`${name}-${option}`} value={option}>
-              {option}
-            </option>
-          ))}
-        </ValidationSelectField>
+        <>
+          <ValidationSelectField
+            name={name}
+            label={label}
+            {...rest}
+            inputRef={ref}
+            defaultValue=""
+            error={!!error}
+            helperText={error?.message}
+            required={required}
+            select
+            SelectProps={{ native: true }}
+          >
+            <option aria-label="None" value="" disabled />
+            {options.map(option => (
+              <option key={`${name}-${option}`} value={option}>
+                {option}
+              </option>
+            ))}
+          </ValidationSelectField>
+          {description && (
+            <FieldTooltip title={description} placement="bottom" arrow>
+              <HelpOutlineIcon className={classes.fieldTip} />
+            </FieldTooltip>
+          )}
+        </>
       )
     }}
   </ConnectForm>
@@ -585,10 +657,11 @@ const ValidationFormControlLabel = withStyles(theme => ({
 /*
  * FormSelectField is rendered for checkboxes
  */
-const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
+const FormBooleanField = ({ name, label, required, description }: FormFieldBaseProps & { description: string }) => (
   <ConnectForm>
     {({ register, errors, getValues }) => {
       const error = _.get(errors, name)
+      const classes = helpIconStyle()
       const { ref, ...rest } = register(name)
       // DAC form: "values" of MainContact checkbox
       const values = getValues(name)
@@ -614,6 +687,11 @@ const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
                   </label>
                 }
               />
+              {description && (
+                <FieldTooltip title={description} placement="bottom" arrow>
+                  <HelpOutlineIcon className={classes.fieldTip} />
+                </FieldTooltip>
+              )}
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>
           </FormControl>
@@ -626,7 +704,13 @@ const FormBooleanField = ({ name, label, required }: FormFieldBaseProps) => (
 /*
  * FormSelectField is rendered for selection from options where it's possible to choose many options
  */
-const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldProps) => (
+const FormCheckBoxArray = ({
+  name,
+  label,
+  required,
+  options,
+  description,
+}: FormSelectFieldProps & { description: string }) => (
   <Box px={1}>
     <p>
       <strong>{label}</strong> - check from following options
@@ -636,27 +720,35 @@ const FormCheckBoxArray = ({ name, label, required, options }: FormSelectFieldPr
         const values = getValues()[name]
 
         const error = _.get(errors, name)
+        const classes = helpIconStyle()
         const { ref, ...rest } = register(name)
 
         return (
           <FormControl error={!!error} required={required}>
             <FormGroup>
               {options.map<React.Element<typeof FormControlLabel>>(option => (
-                <FormControlLabel
-                  key={option}
-                  control={
-                    <Checkbox
-                      name={name}
-                      {...rest}
-                      inputRef={ref}
-                      value={option}
-                      checked={values && values?.includes(option) ? true : false}
-                      color="primary"
-                      defaultValue=""
-                    />
-                  }
-                  label={option}
-                />
+                <React.Fragment key={option}>
+                  <FormControlLabel
+                    key={option}
+                    control={
+                      <Checkbox
+                        name={name}
+                        {...rest}
+                        inputRef={ref}
+                        value={option}
+                        checked={values && values?.includes(option) ? true : false}
+                        color="primary"
+                        defaultValue=""
+                      />
+                    }
+                    label={option}
+                  />
+                  {description && (
+                    <FieldTooltip title={description} placement="bottom" arrow>
+                      <HelpOutlineIcon className={classes.fieldTip} />
+                    </FieldTooltip>
+                  )}
+                </React.Fragment>
               ))}
               <FormHelperText>{error?.message}</FormHelperText>
             </FormGroup>


### PR DESCRIPTION
### Description

A new feature to add description of fields to show as tooltips. Implemented by transferring the description of the field to the icon title tooltip by the field. This is done by following the existing parsing of the forms fields from ENA schema.

### Related issues

Fixes #172

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made
Added Material UI tooltip and Material-UI help icon at /WizardJSONSchemaParser . 
Added check for tootipWizardFillObjectDetailsForm.test.js

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

### Mentions

<!-- Shout outs to your friends that you made this happen or need help. -->
