### PR TITLE
Fix for automatically selected AccessionId in nested fields

### DIFF
--- a/cypress/integration/linkingAccessionIds.spec.js
+++ b/cypress/integration/linkingAccessionIds.spec.js
@@ -109,11 +109,13 @@ describe("Linking Accession Ids", function () {
           .then($btn => $btn.click())
       )
     cy.get("div").contains("Experiment Reference").parent().children("button").click()
+    cy.get("[data-testid='experimentRef[0].label']").type("Test experiment label ref")
     // Select experimentAccessionId
     cy.get("select[name='experimentRef[0].accessionId']").then($el => {
       const experimentAccessionId = cy.get("@experimentAccessionId")
       $el.select(experimentAccessionId)
     })
+
     // Submit Run form
     cy.get("button[type=submit]").contains("Submit").click()
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -199,14 +199,7 @@ const traverseFields = (
     }
     case "string": {
       return object["enum"] ? (
-        <FormSelectField
-          key={name}
-          name={name}
-          label={label}
-          options={object.enum}
-          required={required}
-          nestedField={nestedField}
-        />
+        <FormSelectField key={name} name={name} label={label} options={object.enum} required={required} />
       ) : (
         <FormTextField key={name} name={name} label={label} required={required} nestedField={nestedField} />
       )
@@ -289,7 +282,7 @@ type FormFieldBaseProps = {
   required: boolean,
 }
 
-type FormSelectFieldProps = FormFieldBaseProps & { options: string[], nestedField?: any }
+type FormSelectFieldProps = FormFieldBaseProps & { options: string[] }
 
 /*
  * Highlight required oneOf and select fields
@@ -347,13 +340,14 @@ const FormOneOfField = ({
         // Match key from currentObject to option property.
         // Field key can be deeply nested and therefore we need to have multiple cases for finding correct value.
         if (isNaN(parentPath[0])) {
-          fieldValue = (options.find(option => option.properties[parentPath])
-            ? // Eg. Sample > Sample Names > Sample Data Type
-              options.find(option => option.properties[parentPath])
-            : // Eg. Run > Run Type > Reference Alignment
-              options.find(
-                option => option.properties[Object.keys(flattenObject(itemValues))[0].split(".").slice(-1)[0]]
-              )
+          fieldValue = (
+            options.find(option => option.properties[parentPath])
+              ? // Eg. Sample > Sample Names > Sample Data Type
+                options.find(option => option.properties[parentPath])
+              : // Eg. Run > Run Type > Reference Alignment
+                options.find(
+                  option => option.properties[Object.keys(flattenObject(itemValues))[0].split(".").slice(-1)[0]]
+                )
           )?.title
         } else {
           // Eg. Experiment > Expected Base Call Table > Processing > Single Processing
@@ -545,7 +539,7 @@ const FormTextField = ({
 /*
  * FormSelectField is rendered for choosing one from many options
  */
-const FormSelectField = ({ name, label, required, options, nestedField }: FormSelectFieldProps) => (
+const FormSelectField = ({ name, label, required, options }: FormSelectFieldProps) => (
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
@@ -557,7 +551,7 @@ const FormSelectField = ({ name, label, required, options, nestedField }: FormSe
           label={label}
           {...rest}
           inputRef={ref}
-          defaultValue={getDefaultValue(nestedField, name)}
+          defaultValue=""
           error={!!error}
           helperText={error?.message}
           required={required}


### PR DESCRIPTION
### Description

Fix for referenced `Accession ID` automatically selected in initial render in nested fields.

### Related issues

Fix issue https://github.com/CSCfi/metadata-submitter-frontend/issues/353

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Make `defaultValue` as empty in `FormSelectField` component so it will not take an `accessionId` as its default value


### Testing

- [x] Tests do not apply



