### PR TITLE
Feature/get organizations from ror api

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -3,7 +3,6 @@ describe("Basic e2e", function () {
     cy.login()
   })
 
-
   it("should create new folder, add Study form, upload Study XML file, add Analysis form, add DAC form, and publish folder", () => {
     cy.login()
 
@@ -142,6 +141,8 @@ describe("Basic e2e", function () {
     cy.get("[data-testid='contacts[0].email']").type("email@test.com")
     cy.get("[data-testid='contacts[0].telephoneNumber']").type(123456789)
     cy.get("[data-testid='contacts[0].organisation']").type("Test organization")
+    // Click outside from organisation autocomplete field to hide suggestions
+    cy.get("[data-testid='contacts[0].telephoneNumber']").click()
     cy.get("input[name='contacts[0].mainContact']").check()
 
     // Submit form

--- a/cypress/integration/editForm.spec.js
+++ b/cypress/integration/editForm.spec.js
@@ -57,6 +57,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[data-testid='sampleData.dataDescription']").should("have.value", testData.sampleTypeDescription)
 
     // Clear object in state
+    cy.get("button[type=button]", { timeout: 10000 }).contains("New form").should("exist")
     cy.get("button[type=button]").contains("New form").click()
 
     // Test updated title

--- a/cypress/integration/linkingAccessionIds.spec.js
+++ b/cypress/integration/linkingAccessionIds.spec.js
@@ -206,6 +206,8 @@ describe("Linking Accession Ids", function () {
     cy.get("input[name='contacts[0].email']").type("contact@hotmail.com")
     cy.get("input[name='contacts[0].telephoneNumber']").type("Test phone number")
     cy.get("input[name='contacts[0].organisation']").type("CSC")
+    // Hide autosuggest suggestions by clicking another field
+    cy.get("input[name='contacts[0].telephoneNumber']").click()
     cy.get("input[name='contacts[0].mainContact']").check()
     // Submit DAC form
     cy.get("button[type=submit]").contains("Submit").click()

--- a/cypress/integration/objectTitles.spec.js
+++ b/cypress/integration/objectTitles.spec.js
@@ -32,8 +32,8 @@ describe("draft and submitted objects' titles", function () {
 
     // Edit submitted object
     cy.get("button[type=button]").contains("Edit").click()
-    cy.get("@studyTitle").should("have.value", "Test title")
-    cy.get("@studyTitle").type(" 2").blur()
+    cy.get("@studyTitle", { timeout: 10000 }).should("have.value", "Test title").type(" 2")
+    cy.get("@studyTitle").blur()
     cy.get("@studyTitle").should("have.value", "Test title 2")
     cy.get("button[type=button]").contains("Update", { timeout: 10000 }).click()
     cy.get("div[role=alert]").contains("Object updated")

--- a/cypress/integration/objectTitles.spec.js
+++ b/cypress/integration/objectTitles.spec.js
@@ -15,9 +15,12 @@ describe("draft and submitted objects' titles", function () {
     cy.get("div[role=button]").contains("Study").click()
     cy.get("div[role=button]").contains("Fill Form").click()
 
+    // Variables
+    cy.get("input[name='descriptor.studyTitle']").as("studyTitle")
+
     // Fill a Study form and submit object
-    cy.get("input[name='descriptor.studyTitle']").type("Test title")
-    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title")
+    cy.get("@studyTitle").type("Test title")
+    cy.get("@studyTitle").should("have.value", "Test title")
     cy.get("select[name='descriptor.studyType']").select("Metagenomics")
 
     // Submit form
@@ -29,8 +32,9 @@ describe("draft and submitted objects' titles", function () {
 
     // Edit submitted object
     cy.get("button[type=button]").contains("Edit").click()
-    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title").type(" 2").blur()
-    cy.get("input[name='descriptor.studyTitle']").should("have.value", "Test title 2")
+    cy.get("@studyTitle").should("have.value", "Test title")
+    cy.get("@studyTitle").type(" 2").blur()
+    cy.get("@studyTitle").should("have.value", "Test title 2")
     cy.get("button[type=button]").contains("Update", { timeout: 10000 }).click()
     cy.get("div[role=alert]").contains("Object updated")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "http-proxy-middleware": "^2.0.1",
         "husky": "^7.0.1",
         "jest": "26.6.0",
+        "msw": "^0.29.0",
         "pinst": "^2.1.6",
         "prettier": "^2.3.2",
         "redux-mock-store": "^1.5.4",
@@ -2302,6 +2303,29 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
+      "integrity": "sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.10.0.tgz",
+      "integrity": "sha512-/M0GGpid5q2EDI+Keas1sLYF3VZFXHDE5gCmX/jHdp+OJFruVNca3PUk7A8KnGdPpuycZogdPsmRBSOXwjyA7A==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "debug": "^4.3.0",
+        "headers-utils": "^3.0.2",
+        "strict-event-emitter": "^0.2.0",
+        "xmldom": "^0.6.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -2356,6 +2380,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.6.1",
@@ -2852,6 +2882,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "7.2.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -2906,6 +2942,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/inquirer": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.2.tgz",
+      "integrity": "sha512-EkeX/hU0SWinA2c7Qu/+6+7KbepFPYJcjankUgtA/VSY6BlVHybL0Cgyey9PDbXwhNXnNGBLU3t+MORp23RgAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -2935,6 +2981,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
@@ -3028,6 +3080,15 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz",
+      "integrity": "sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -3061,6 +3122,15 @@
       "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
       "dependencies": {
         "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/uglify-js": {
@@ -4647,6 +4717,55 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -5152,6 +5271,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -5344,6 +5469,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -5374,6 +5511,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cliui": {
@@ -6683,6 +6829,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
       }
     },
     "node_modules/define-properties": {
@@ -8436,6 +8591,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -9480,6 +9661,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "node_modules/graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -9695,6 +9885,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "dev": true
     },
     "node_modules/hex-color-regex": {
       "version": "1.1.0",
@@ -10261,6 +10457,71 @@
         "node": ">=10"
       }
     },
+    "node_modules/inquirer": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
+      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.3.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.6",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -10553,6 +10814,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-module": {
@@ -11801,6 +12071,15 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12912,6 +13191,85 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.29.0.tgz",
+      "integrity": "sha512-C/wz1d5uAEZRvAPAYrXG1rwLxXl0+BOs+JPrCzasoABZW3ATwS6ifSze+/DAgA93e9M86RXwvy6yDtZeZWmCFQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.1.5",
+        "@mswjs/interceptors": "^0.10.0",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.0",
+        "@types/inquirer": "^7.3.1",
+        "@types/js-levenshtein": "^1.1.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.1",
+        "graphql": "^15.4.0",
+        "headers-utils": "^3.0.2",
+        "inquirer": "^8.1.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.1",
+        "node-match-path": "^0.6.3",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.0",
+        "type-fest": "^1.1.3",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/msw/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+      "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -12928,6 +13286,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.14.2",
@@ -13012,6 +13376,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -13059,6 +13432,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "node_modules/node-match-path": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-match-path/-/node-match-path-0.6.3.tgz",
+      "integrity": "sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==",
+      "dev": true
     },
     "node_modules/node-modules-regexp": {
       "version": "1.0.0",
@@ -13510,6 +13889,54 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -13522,6 +13949,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ospath": {
       "version": "1.2.2",
@@ -17165,6 +17601,15 @@
         "node": "6.* || >= 7.*"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17820,6 +18265,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -18898,6 +19349,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+      "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
@@ -20684,6 +21144,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -22206,6 +22675,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -24061,6 +24539,29 @@
         "react-is": "^16.8.0 || ^17.0.0"
       }
     },
+    "@mswjs/cookies": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
+      "integrity": "sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==",
+      "dev": true,
+      "requires": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "@mswjs/interceptors": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.10.0.tgz",
+      "integrity": "sha512-/M0GGpid5q2EDI+Keas1sLYF3VZFXHDE5gCmX/jHdp+OJFruVNca3PUk7A8KnGdPpuycZogdPsmRBSOXwjyA7A==",
+      "dev": true,
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "debug": "^4.3.0",
+        "headers-utils": "^3.0.2",
+        "strict-event-emitter": "^0.2.0",
+        "xmldom": "^0.6.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -24099,6 +24600,12 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "@reduxjs/toolkit": {
       "version": "1.6.1",
@@ -24435,6 +24942,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.2.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
@@ -24489,6 +25002,16 @@
         "@types/node": "*"
       }
     },
+    "@types/inquirer": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.2.tgz",
+      "integrity": "sha512-EkeX/hU0SWinA2c7Qu/+6+7KbepFPYJcjankUgtA/VSY6BlVHybL0Cgyey9PDbXwhNXnNGBLU3t+MORp23RgAw==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -24518,6 +25041,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.7",
@@ -24613,6 +25142,15 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
+    "@types/set-cookie-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz",
+      "integrity": "sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -24646,6 +25184,15 @@
       "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
       "requires": {
         "@types/jest": "*"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/uglify-js": {
@@ -25884,6 +26431,40 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -26304,6 +26885,12 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -26455,6 +27042,12 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true
+    },
     "cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -26476,6 +27069,12 @@
         "string-width": "^4.2.0"
       }
     },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -26486,6 +27085,12 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clsx": {
       "version": "1.1.1",
@@ -27520,6 +28125,15 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -28884,6 +29498,28 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -29668,6 +30304,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "graphql": {
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -29837,6 +30479,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "dev": true
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -30281,6 +30929,58 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
+    "inquirer": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
+      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.3.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.6",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -30481,6 +31181,12 @@
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
       }
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
     },
     "is-module": {
       "version": "1.0.0",
@@ -31422,6 +32128,12 @@
         "supports-color": "^7.0.0"
       }
     },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -32306,6 +33018,68 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msw": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.29.0.tgz",
+      "integrity": "sha512-C/wz1d5uAEZRvAPAYrXG1rwLxXl0+BOs+JPrCzasoABZW3ATwS6ifSze+/DAgA93e9M86RXwvy6yDtZeZWmCFQ==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.1.5",
+        "@mswjs/interceptors": "^0.10.0",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.0",
+        "@types/inquirer": "^7.3.1",
+        "@types/js-levenshtein": "^1.1.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.1",
+        "graphql": "^15.4.0",
+        "headers-utils": "^3.0.2",
+        "inquirer": "^8.1.0",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.1",
+        "node-match-path": "^0.6.3",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.0",
+        "type-fest": "^1.1.3",
+        "yargs": "^17.0.1"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+          "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        }
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -32319,6 +33093,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "nan": {
       "version": "2.14.2",
@@ -32391,6 +33171,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -32437,6 +33223,12 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
+    },
+    "node-match-path": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-match-path/-/node-match-path-0.6.3.tgz",
+      "integrity": "sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==",
+      "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -32775,6 +33567,44 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -32787,6 +33617,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "ospath": {
       "version": "1.2.2",
@@ -35660,6 +36496,12 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -36167,6 +37009,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-cookie-parser": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -37061,6 +37909,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "strict-event-emitter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+      "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+      "dev": true,
+      "requires": {
+        "events": "^3.3.0"
+      }
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -38460,6 +39317,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -39683,6 +40549,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/@types/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
     "node_modules/@types/eslint": {
@@ -2943,9 +2943,9 @@
       }
     },
     "node_modules/@types/inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-EkeX/hU0SWinA2c7Qu/+6+7KbepFPYJcjankUgtA/VSY6BlVHybL0Cgyey9PDbXwhNXnNGBLU3t+MORp23RgAw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==",
       "dev": true,
       "dependencies": {
         "@types/through": "*",
@@ -3081,9 +3081,9 @@
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz",
-      "integrity": "sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.1.tgz",
+      "integrity": "sha512-N0IWe4vT1w5IOYdN9c9PNpQniHS+qe25W4tj4vfhJDJ9OkvA/YA55YUhaC+HNmMMeLlOSnBW9UMno0qlt5xu3Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5531,6 +5531,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -10458,9 +10467,9 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
-      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+      "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -10473,7 +10482,7 @@
         "mute-stream": "0.0.8",
         "ora": "^5.3.0",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.6",
+        "rxjs": "^7.2.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -10482,45 +10491,20 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/inquirer/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "tslib": "~2.1.0"
       }
     },
-    "node_modules/inquirer/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/inquirer/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
     },
     "node_modules/internal-ip": {
       "version": "4.3.0",
@@ -13241,9 +13225,9 @@
       }
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
-      "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -13253,9 +13237,9 @@
       }
     },
     "node_modules/msw/node_modules/yargs": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.0.tgz",
+      "integrity": "sha512-SQr7qqmQ2sNijjJGHL4u7t8vyDZdZ3Ahkmo4sc1w5xI9TBX0QDdG/g4SFnxtWOsGLjwHQue57eFALfwFCnixgg==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -13910,31 +13894,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/original": {
@@ -24943,9 +24902,9 @@
       }
     },
     "@types/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
     "@types/eslint": {
@@ -25003,9 +24962,9 @@
       }
     },
     "@types/inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-EkeX/hU0SWinA2c7Qu/+6+7KbepFPYJcjankUgtA/VSY6BlVHybL0Cgyey9PDbXwhNXnNGBLU3t+MORp23RgAw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==",
       "dev": true,
       "requires": {
         "@types/through": "*",
@@ -25143,9 +25102,9 @@
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/set-cookie-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz",
-      "integrity": "sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.1.tgz",
+      "integrity": "sha512-N0IWe4vT1w5IOYdN9c9PNpQniHS+qe25W4tj4vfhJDJ9OkvA/YA55YUhaC+HNmMMeLlOSnBW9UMno0qlt5xu3Q==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -25589,9 +25548,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
       "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -30930,9 +30887,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
-      "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+      "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -30945,39 +30902,26 @@
         "mute-stream": "0.0.8",
         "ora": "^5.3.0",
         "run-async": "^2.4.0",
-        "rxjs": "^6.6.6",
+        "rxjs": "^7.2.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+        "rxjs": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+          "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
           "dev": true,
           "requires": {
-            "restore-cursor": "^3.1.0"
+            "tslib": "~2.1.0"
           }
         },
-        "figures": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
         }
       }
     },
@@ -33058,15 +33002,15 @@
           "dev": true
         },
         "type-fest": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
-          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         },
         "yargs": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-          "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+          "version": "17.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.0.tgz",
+          "integrity": "sha512-SQr7qqmQ2sNijjJGHL4u7t8vyDZdZ3Ahkmo4sc1w5xI9TBX0QDdG/g4SFnxtWOsGLjwHQue57eFALfwFCnixgg==",
           "dev": true,
           "requires": {
             "cliui": "^7.0.2",
@@ -33582,27 +33526,6 @@
         "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        }
       }
     },
     "original": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "http-proxy-middleware": "^2.0.1",
     "husky": "^7.0.1",
     "jest": "26.6.0",
+    "msw": "^0.29.0",
     "pinst": "^2.1.6",
     "prettier": "^2.3.2",
     "redux-mock-store": "^1.5.4",

--- a/src/__tests__/FormAutocompleteField.test.js
+++ b/src/__tests__/FormAutocompleteField.test.js
@@ -1,0 +1,100 @@
+import React from "react"
+
+import "@testing-library/jest-dom/extend-expect"
+import { ThemeProvider } from "@material-ui/core/styles"
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react"
+import { rest } from "msw"
+import { setupServer } from "msw/node"
+import { Provider } from "react-redux"
+import configureStore from "redux-mock-store"
+
+import WizardFillObjectDetailsForm from "../components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm"
+import CSCtheme from "../theme"
+
+import { ObjectSubmissionTypes, ObjectTypes } from "constants/wizardObject"
+
+const mockStore = configureStore([])
+
+const mockOrganisations = [{ name: "Test Organisation" }, { name: "Mock Org" }]
+
+// MSWJS tries onUnhandledRequest method, which defaults to GraphQL query if GET call has query params
+const server = setupServer(
+  rest.get("/organizations", (req, res, ctx) => {
+    return res(ctx.json({ ok: true, data: { items: mockOrganisations } }))
+  })
+)
+
+describe("Test autocomplete on organisation field", () => {
+  const schema = {
+    title: "DAC",
+    type: "object",
+    properties: {
+      organisation: {
+        type: "string",
+        title: "Organisation",
+      },
+    },
+  }
+
+  const store = mockStore({
+    objectType: ObjectTypes.dac,
+    submissionType: ObjectSubmissionTypes.form,
+    submissionFolder: {
+      description: "Test desciption",
+      id: "FOL90524783",
+      name: "Test name",
+      published: false,
+    },
+  })
+
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  sessionStorage.setItem(`cached_dac_schema`, JSON.stringify(schema))
+
+  it("should render autocomplete field if schema has 'organisation' property", async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={CSCtheme}>
+          <WizardFillObjectDetailsForm />
+        </ThemeProvider>
+      </Provider>
+    )
+    await waitFor(() => {
+      const autocomplete = screen.getByTestId("organisation")
+      expect(autocomplete).toBeDefined()
+    })
+  })
+
+  it("should search for organisations", async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={CSCtheme}>
+          <WizardFillObjectDetailsForm />
+        </ThemeProvider>
+      </Provider>
+    )
+
+    server.listen({
+      onUnhandledRequest: "warn",
+    })
+
+    await waitFor(() => {
+      const autocomplete = screen.getByTestId("organisation")
+      const input = within(autocomplete).getByRole("textbox")
+
+      autocomplete.focus()
+      // assign value to input field
+      fireEvent.change(input, { target: { value: "test" } })
+
+      // navigate to the first item in the autocomplete box
+      fireEvent.keyDown(autocomplete, { key: "ArrowDown" })
+
+      // select the first item
+      fireEvent.keyDown(autocomplete, { key: "Enter" })
+      // check the new value of the input field
+      expect(input.value).toEqual(mockOrganisations[0].name)
+    })
+  })
+})

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -201,9 +201,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
 
   const methods = useForm({ mode: "onBlur", resolver })
 
-  const [cleanedValues, setCleanedValues] = useState({})
   const [currentObjectId, setCurrentObjectId] = useState(currentObject?.accessionId)
-
   const [draftAutoSaveAllowed, setDraftAutoSaveAllowed] = useState(false)
 
   const autoSaveTimer = useRef(null)
@@ -211,8 +209,7 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
 
   // Set form default values
   useEffect(() => {
-    methods.reset(cloneDeep(currentObject))
-    setCleanedValues(currentObject)
+    methods.reset(currentObject)
   }, [currentObject?.accessionId])
 
   // Check if form has been edited
@@ -230,7 +227,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   const clearForm = () => {
     resetTimer()
     methods.reset({})
-    setCleanedValues({})
     dispatch(resetDraftStatus())
   }
 
@@ -240,17 +236,17 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   }
 
   const checkDirty = () => {
-    if (methods.formState.isDirty && draftStatus === "" && checkFormCleanedValuesEmpty(cleanedValues)) {
+    if (methods.formState.isDirty && draftStatus === "" && checkFormCleanedValuesEmpty(getCleanedValues())) {
       dispatch(setDraftStatus("notSaved"))
     }
   }
+
+  const getCleanedValues = () => JSONSchemaParser.cleanUpFormValues(methods.getValues())
 
   // Draft data is set to state on every change to form
   const handleChange = () => {
     const clone = cloneDeep(currentObject)
     const values = JSONSchemaParser.cleanUpFormValues(methods.getValues())
-
-    setCleanedValues(values)
 
     if (clone && checkFormCleanedValuesEmpty(values)) {
       Object.keys(values).forEach(item => (clone[item] = values[item]))
@@ -359,13 +355,15 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
    */
   const saveDraft = async () => {
     resetTimer()
+    const cleanedValues = getCleanedValues()
+
     if (checkFormCleanedValuesEmpty(cleanedValues)) {
       const handleSave = await saveDraftHook(
         currentObject.accessionId || currentObject.objectId,
         objectType,
         currentObject.status,
         folderId,
-        cleanedValues || currentObject.cleanedValues,
+        cleanedValues,
         dispatch
       )
       if (handleSave.ok && currentObject?.status !== ObjectStatus.submitted) {
@@ -383,6 +381,8 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   }
 
   const patchObject = async () => {
+    resetTimer()
+    const cleanedValues = getCleanedValues()
     const response = await objectAPIService.patchFromJSON(objectType, currentObjectId, cleanedValues)
     patchHandler(response, cleanedValues)
   }

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -19,6 +19,7 @@ import Tooltip from "@material-ui/core/Tooltip"
 import Typography from "@material-ui/core/Typography"
 import AddIcon from "@material-ui/icons/Add"
 import HelpOutlineIcon from "@material-ui/icons/HelpOutline"
+import LaunchIcon from "@material-ui/icons/Launch"
 import RemoveIcon from "@material-ui/icons/Remove"
 import Autocomplete from "@material-ui/lab/Autocomplete"
 import * as _ from "lodash"
@@ -45,7 +46,11 @@ const useStyles = makeStyles(theme => ({
   },
   divBaseline: {
     display: "flex",
+    flexDirection: "row",
     alignItems: "baseline",
+    "& label": {
+      marginRight: theme.spacing(0),
+    },
   },
   autocomplete: {
     flex: "auto",
@@ -53,6 +58,10 @@ const useStyles = makeStyles(theme => ({
     "& + svg": {
       marginTop: theme.spacing(1),
     },
+  },
+  externalLink: {
+    fontSize: "1rem",
+    marginBottom: theme.spacing(-0.5),
   },
 }))
 
@@ -746,7 +755,23 @@ const FormAutocompleteField = ({
                 value={defaultValue}
               />
               {description && (
-                <FieldTooltip title={description} placement="top" arrow>
+                <FieldTooltip
+                  title={
+                    <React.Fragment>
+                      {description}
+                      <br />
+                      {"Organisations provided by "}
+                      <a href="https://ror.org/" target="_blank" rel="noreferrer">
+                        {"ror.org"}
+                        <LaunchIcon className={classes.externalLink} />
+                      </a>
+                      {"."}
+                    </React.Fragment>
+                  }
+                  placement="top"
+                  arrow
+                  interactive
+                >
                   <HelpOutlineIcon className={classes.fieldTip} />
                 </FieldTooltip>
               )}
@@ -831,7 +856,7 @@ const FormBooleanField = ({ name, label, required, description }: FormFieldBaseP
       return (
         <Box display="inline" px={1}>
           <FormControl error={!!error} required={required}>
-            <FormGroup>
+            <FormGroup className={classes.divBaseline}>
               <ValidationFormControlLabel
                 control={
                   <Checkbox

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -38,7 +38,7 @@ const highlightStyle = theme => {
   }
 }
 
-const helpIconStyle = makeStyles(theme => ({
+const useStyles = makeStyles(theme => ({
   fieldTip: {
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
@@ -46,6 +46,13 @@ const helpIconStyle = makeStyles(theme => ({
   divBaseline: {
     display: "flex",
     alignItems: "baseline",
+  },
+  autocomplete: {
+    flex: "auto",
+    alignSelf: "flex-start",
+    "& + svg": {
+      marginTop: theme.spacing(1),
+    },
   },
 }))
 
@@ -238,7 +245,14 @@ const traverseFields = (
           description={description}
         />
       ) : autoCompleteIdentifiers.some(value => label.toLowerCase().includes(value)) ? (
-        <FormAutocompleteField key={name} name={name} label={label} required={required} nestedField={nestedField} />
+        <FormAutocompleteField
+          key={name}
+          name={name}
+          label={label}
+          required={required}
+          nestedField={nestedField}
+          description={description}
+        />
       ) : (
         <FormTextField
           key={name}
@@ -486,7 +500,7 @@ const FormOneOfField = ({
           if (val === "Null value") setValue(name, null)
         }
 
-        const classes = helpIconStyle()
+        const classes = useStyles()
         // Selected option
         const selectedOption = options?.filter(option => option.title === field)[0]?.properties || {}
         const selectedOptionValues = Object.values(selectedOption)
@@ -576,7 +590,7 @@ const FormTextField = ({
 }: FormFieldBaseProps & { description: string, type?: string, nestedField?: any }) => (
   <ConnectForm>
     {({ control }) => {
-      const classes = helpIconStyle()
+      const classes = useStyles()
       const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
       return (
         <Controller
@@ -625,10 +639,12 @@ const FormAutocompleteField = ({
   name,
   label,
   required,
-}: FormFieldBaseProps & { type?: string, nestedField?: any }) => (
+  description,
+}: FormFieldBaseProps & { type?: string, nestedField?: any, description: string }) => (
   <ConnectForm>
     {({ errors, getValues, control, setValue }) => {
       const error = _.get(errors, name)
+      const classes = useStyles()
 
       const [selection, setSelection] = useState(null)
       const [open, setOpen] = useState(false)
@@ -678,48 +694,57 @@ const FormAutocompleteField = ({
       return (
         <Controller
           render={() => (
-            <Autocomplete
-              freeSolo
-              open={open}
-              onOpen={() => {
-                setOpen(true)
-              }}
-              onClose={() => {
-                setOpen(false)
-              }}
-              options={options}
-              getOptionLabel={option => option.name || defaultValue}
-              data-testid={name}
-              disableClearable={inputValue.length === 0}
-              renderInput={params => (
-                <TextField
-                  {...params}
-                  label={label}
-                  variant="outlined"
-                  error={!!error}
-                  required={required}
-                  InputProps={{
-                    ...params.InputProps,
-                    endAdornment: (
-                      <React.Fragment>
-                        {loading ? <CircularProgress color="inherit" size={20} /> : null}
-                        {params.InputProps.endAdornment}
-                      </React.Fragment>
-                    ),
-                  }}
-                />
+            <div className={classes.divBaseline}>
+              <Autocomplete
+                freeSolo
+                className={classes.autocomplete}
+                open={open}
+                onOpen={() => {
+                  setOpen(true)
+                }}
+                onClose={() => {
+                  setOpen(false)
+                }}
+                options={options}
+                getOptionLabel={option => option.name || defaultValue}
+                data-testid={name}
+                disableClearable={inputValue.length === 0}
+                renderInput={params => (
+                  <TextField
+                    {...params}
+                    label={label}
+                    name={name}
+                    variant="outlined"
+                    error={!!error}
+                    required={required}
+                    InputProps={{
+                      ...params.InputProps,
+                      endAdornment: (
+                        <React.Fragment>
+                          {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                          {params.InputProps.endAdornment}
+                        </React.Fragment>
+                      ),
+                    }}
+                  />
+                )}
+                onChange={(event, option) => {
+                  setSelection(option)
+                  setValue(name, option?.name)
+                }}
+                onInputChange={(event, newInputValue) => {
+                  setOptions([])
+                  setInputValue(newInputValue)
+                  setValue(name, newInputValue)
+                }}
+                value={defaultValue}
+              />
+              {description && (
+                <FieldTooltip title={description} placement="top" arrow>
+                  <HelpOutlineIcon className={classes.fieldTip} />
+                </FieldTooltip>
               )}
-              onChange={(event, option) => {
-                setSelection(option)
-                setValue(name, option?.name)
-              }}
-              onInputChange={(event, newInputValue) => {
-                setOptions([])
-                setInputValue(newInputValue)
-                setValue(name, newInputValue)
-              }}
-              value={defaultValue}
-            />
+            </div>
           )}
           name={name}
           control={control}
@@ -742,7 +767,7 @@ const FormSelectField = ({
   <ConnectForm>
     {({ register, errors }) => {
       const error = _.get(errors, name)
-      const classes = helpIconStyle()
+      const classes = useStyles()
       const { ref, ...rest } = register(name)
 
       return (
@@ -793,7 +818,7 @@ const FormBooleanField = ({ name, label, required, description }: FormFieldBaseP
   <ConnectForm>
     {({ register, errors, getValues }) => {
       const error = _.get(errors, name)
-      const classes = helpIconStyle()
+      const classes = useStyles()
       const { ref, ...rest } = register(name)
       // DAC form: "values" of MainContact checkbox
       const values = getValues(name)
@@ -852,7 +877,7 @@ const FormCheckBoxArray = ({
         const values = getValues()[name]
 
         const error = _.get(errors, name)
-        const classes = helpIconStyle()
+        const classes = useStyles()
         const { ref, ...rest } = register(name)
 
         return (

--- a/src/services/rorAPI.js
+++ b/src/services/rorAPI.js
@@ -1,0 +1,17 @@
+//@flow
+import { create } from "apisauce"
+
+import { errorMonitor } from "./errorMonitor"
+
+const api = create({ baseURL: "http://api.ror.org" })
+api.addMonitor(errorMonitor)
+
+const getOrganisations = async (searchTerm: string): Promise<any> => {
+  const query = searchTerm?.length ? `?query=${searchTerm}` : ""
+
+  return await api.get("/organizations" + query)
+}
+
+export default {
+  getOrganisations,
+}

--- a/src/services/rorAPI.js
+++ b/src/services/rorAPI.js
@@ -7,9 +7,7 @@ const api = create({ baseURL: "http://api.ror.org" })
 api.addMonitor(errorMonitor)
 
 const getOrganisations = async (searchTerm: string): Promise<any> => {
-  const query = searchTerm?.length ? `?query=${searchTerm}` : ""
-
-  return await api.get("/organizations" + query)
+  return await api.get("/organizations", { query: searchTerm })
 }
 
 export default {


### PR DESCRIPTION
### Description

Forms with `organisation` property in form schema are treated as autocomplete fields. Data is fetched from ROR API.

### Related issues

Closes #176 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Use MaterialUI autocomplete field if field name is among `autoCompleteIdentifiers`. 
- More straightforward form data assertion and form reset. Helps when rendering edited form with autocomplete field.
- Search ROR API for matching organisation name
- Autocomplete + tooltip icon combination styling and positioning
- Jest tests with Mock Service Worker library
- Fixed E2E tests to work with autocomplete field

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests

