### PR TITLE
 Fix for object before patching

### DIFF
--- a/cypress/integration/editForm.spec.js
+++ b/cypress/integration/editForm.spec.js
@@ -16,15 +16,17 @@ describe("Populate form and render form elements by object data", function () {
     const testData = {
       title: "Sample test title",
       taxonId: "123456",
-      sampleData: "Human Sample",
+      sampleData1: "Human Sample",
       gender: "unknown",
+      sampleData2: "Non Human Sample",
+      sampleTypeDescription: "Non Human Sample Description",
     }
 
     cy.clickFillForm("Sample")
 
     cy.get("input[name='title']").type(testData.title)
     cy.get("input[name='sampleName.taxonId']").type(testData.taxonId)
-    cy.get("select[name='sampleData']").select(testData.sampleData)
+    cy.get("select[name='sampleData']").select(testData.sampleData1)
     cy.get("select[name='sampleData.gender']").select(testData.gender)
 
     // Submit form
@@ -40,10 +42,19 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("input[name='title']", { timeout: 10000 }).focus().type(" edited").blur()
     cy.get("input[name='title']").should("have.value", `${testData.title} edited`)
     cy.get("input[name='sampleName.taxonId']").should("have.value", testData.taxonId)
-    cy.get("select[name='sampleData']").should("have.value", testData.sampleData)
+    cy.get("select[name='sampleData']").should("have.value", testData.sampleData1)
     cy.get("select[name='sampleData.gender']").should("have.value", testData.gender)
+
+    // Change Sample Data Type to Non Human Sample
+    cy.get("select[name='sampleData']").select(testData.sampleData2)
+    cy.get("[data-testid='sampleData.dataDescription']").type(testData.sampleTypeDescription)
     cy.get("button[type=button]").contains("Update").click()
     cy.get("div[role=alert]").contains("Object updated")
+
+    // Check Sample form renders Non Human Sample now
+    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("select[name='sampleData']").should("have.value", testData.sampleData2)
+    cy.get("[data-testid='sampleData.dataDescription']").should("have.value", testData.sampleTypeDescription)
 
     // Clear object in state
     cy.get("button[type=button]").contains("New form").click()
@@ -93,7 +104,9 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("h2[data-testid='processing']").parent().children("button").click()
     cy.get(".MuiPaper-root > :nth-child(1) > .formSection > .array > .MuiButtonBase-root > .MuiButton-label").click()
     cy.get("input[data-testid='processing[0].pipeline.pipeSection[0].stepIndex']").type(testData.stepIndex)
-    cy.get("select[name='processing[0].pipeline.pipeSection[0].prevStepIndex']").select(testData.stringValue)
+    cy.get("select[name='processing[0].pipeline.pipeSection[0].prevStepIndex']", { force: true }).select(
+      testData.stringValue
+    )
     cy.get("input[data-testid='processing[0].pipeline.pipeSection[0].prevStepIndex']").type(testData.prevStepIndexValue)
 
     // Save Experiment form

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -249,7 +249,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folderId, cur
   const handleChange = () => {
     const clone = cloneDeep(currentObject)
     const values = JSONSchemaParser.cleanUpFormValues(methods.getValues())
-
     setCleanedValues(values)
 
     if (clone && checkFormCleanedValuesEmpty(values)) {

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -391,7 +391,6 @@ const FormOneOfField = ({
       if (values[item]) {
         const itemValues = values[item]
         const parentPath = Object.keys(itemValues) ? Object.keys(itemValues) : ""
-
         // Match key from currentObject to option property.
         // Field key can be deeply nested and therefore we need to have multiple cases for finding correct value.
         if (isNaN(parentPath[0])) {
@@ -429,6 +428,7 @@ const FormOneOfField = ({
   // Special handling for Expected Base Call Table > Processing > Complex Processing > Pipeline > Pipe Section > Prev Step Index
   // Can be extended to other fields if needed
   const itemValue = get(currentObject, pathToName(path))
+
   if (itemValue) {
     switch (lastPathItem) {
       case "prevStepIndex":
@@ -465,7 +465,7 @@ const FormOneOfField = ({
 
   return (
     <ConnectForm>
-      {({ errors, unregister, setValue }) => {
+      {({ errors, unregister, setValue, getValues, reset }) => {
         const error = _.get(errors, name)
         // Option change handling
         const [field, setField] = useState(fieldValue)
@@ -474,9 +474,15 @@ const FormOneOfField = ({
           const val = event.target.value
           setField(val)
 
+          // Get fieldValues of current path
+          const currentFieldValues = getValues(name)
           // Unregister if selecting "Complex Processing", "Null value" in Experiment form
           if (val === "Complex Processing") unregister(name)
           if (val === "Null value") setValue(name, null)
+          // Remove previous values of the same path
+          if (val !== "Complex Processing" && val !== "Null value" && currentFieldValues !== undefined) {
+            reset({ ...getValues(), [name]: "" })
+          }
         }
 
         const classes = helpIconStyle()


### PR DESCRIPTION
### Description

`Sample Data Type` in **Sample** form is overwritten with only one value before the object is patched.
### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/321

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

- Remove the previous value (if exists) when selecting a new field of the same path in form 

### Testing

- [x] Integration Tests



