### PR TITLE
Feature/form section tooltips

### DIFF
--- a/src/__tests__/WizardFillObjectDetailsForm.test.js
+++ b/src/__tests__/WizardFillObjectDetailsForm.test.js
@@ -36,6 +36,18 @@ describe("WizardFillObjectDetailsForm", () => {
           },
         },
       },
+      center: {
+        title: "Description for Center",
+        description: "More for backwards compatibility, we might not need it.",
+        type: "object",
+        properties: {
+            centerProjectName: {
+                title: "Center Project Name",
+                description: " Submitter defined project name. This field is intended for backward tracking of the study record to the submitter's LIMS.",
+                type: "string"
+            }
+        }
+    }
     },
   }
 
@@ -96,8 +108,12 @@ describe("WizardFillObjectDetailsForm", () => {
       const tooltip = screen.getByTitle("Title of the study as would be used in a publication.")
       fireEvent.mouseOver(tooltip)
       expect(tooltip).toBeVisible()
-    }
-    )
+    })
+    await waitFor(() => {
+      const tooltip = screen.getByTitle("More for backwards compatibility, we might not need it.")
+      fireEvent.mouseOver(tooltip)
+      expect(tooltip).toBeVisible()
+    })
   }
 
   )

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -75,6 +75,7 @@ const FieldTooltip = withStyles(theme => ({
     color: theme.palette.common.black,
     fontSize: theme.typography.pxToRem(14),
     boxShadow: theme.shadows[1],
+    maxWidth: 400,
   },
 }))(Tooltip)
 

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -335,7 +335,7 @@ type FormSectionProps = {
  * FormSection is rendered for properties with type object
  */
 const FormSection = ({ name, label, level, children, description, }: FormSectionProps & { description: string }) => {
-  const classes = helpIconStyle()
+  const classes = useStyles()
 
   return (
     <ConnectForm>
@@ -352,7 +352,6 @@ const FormSection = ({ name, label, level, children, description, }: FormSection
                     </FieldTooltip>
                   )}
               </Typography>
-
               {children}
             </div>
             <div>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -44,6 +44,10 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.main,
     marginLeft: theme.spacing(0),
   },
+  sectionTip: {
+    fontSize: "inherit",
+    marginLeft: theme.spacing(0.5),
+  },
   divBaseline: {
     display: "flex",
     flexDirection: "row",
@@ -223,7 +227,7 @@ const traverseFields = (
     case "object": {
       const properties = object.properties
       return (
-        <FormSection key={name} name={name} label={label} level={path.length + 1}>
+        <FormSection key={name} name={name} label={label} level={path.length + 1} description={description}>
           {Object.keys(properties).map(propertyKey => {
             const property = properties[propertyKey]
             let required = object?.else?.required ?? object.required
@@ -330,8 +334,8 @@ type FormSectionProps = {
 /*
  * FormSection is rendered for properties with type object
  */
-const FormSection = (props: FormSectionProps) => {
-  const { name, label, level } = props
+const FormSection = ({ name, label, level, children, description, }: FormSectionProps & { description: string }) => {
+  const classes = helpIconStyle()
 
   return (
     <ConnectForm>
@@ -342,8 +346,14 @@ const FormSection = (props: FormSectionProps) => {
             <div className="formSection" key={`${name}-section`}>
               <Typography key={`${name}-header`} variant={`h${level}`}>
                 {label}
+                {description && level==2 && (
+                    <FieldTooltip title={description} placement="top" arrow>
+                      <HelpOutlineIcon className={classes.sectionTip} />
+                    </FieldTooltip>
+                  )}
               </Typography>
-              {props.children}
+
+              {children}
             </div>
             <div>
               {error ? (


### PR DESCRIPTION
### Description

Add a new question mark icon for section tooltip and condition it by existing description.

### Related issues

Fixes #364

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (this needs a follow up PR)

### Changes Made

<!-- List changes made. -->
WizardJSONSchemaParser.js :
New style for tooltip: sectionTip
Add tooltip for sections, only if description exist and only for level 2.

WizardFillObjectDetailsForm.test.js

### Testing

- [x ] Unit Tests
- [ ] Integration Tests
- [ ] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)

