### PR TITLE
Fix for pagination's usability

### DIFF
--- a/cypress/integration/pagination.spec.js
+++ b/cypress/integration/pagination.spec.js
@@ -139,10 +139,12 @@ describe("unpublished folders, published folders, and user's draft templates pag
     )
     cy.login()
     cy.get("button[data-testid='ViewAll-draft']", { timeout: 10000 }).click()
+    cy.get("[data-testid='page info']").contains("1 of 20 pages").should("be.visible")
 
     // Click Next page button
-    cy.get("button[aria-label='Next page']").click()
+    cy.get("button[aria-label='next page']").click()
     cy.get("p").contains("11-20 of 200").should("be.visible")
+    cy.get("[data-testid='page info']").contains("2 of 20 pages").should("be.visible")
 
     // Check "Items per page" options
     cy.get("div[aria-haspopup='listbox']", { timeout: 10000 }).contains(10).click()
@@ -154,6 +156,7 @@ describe("unpublished folders, published folders, and user's draft templates pag
     cy.get("li[data-value='50']").click()
     cy.get("ul > a", { timeout: 10000 }).should("have.length", "50")
     cy.get("p", { timeout: 10000 }).contains("1-50 of 200").should("be.visible")
+    cy.get("[data-testid='page info']").contains("1 of 4 pages").should("be.visible")
   })
 
   it("should renders pagination for unpublished folders list correctly", () => {
@@ -298,9 +301,12 @@ describe("unpublished folders, published folders, and user's draft templates pag
     cy.login()
     cy.get("button[data-testid='ViewAll-published']", { timeout: 10000 }).click()
 
+    cy.get("[data-testid='page info']").should("be.visible")
+    cy.get("[data-testid='page info']").contains("1 of 8 pages").should("be.visible")
     // Click Next page button
-    cy.get("button[aria-label='Next page']").click()
+    cy.get("button[aria-label='next page']").click()
     cy.get("p", { timeout: 10000 }).contains("11-20 of 80").should("be.visible")
+    cy.get("[data-testid='page info']").contains("2 of 8 pages").should("be.visible")
 
     // Check "Items per page" options
     cy.get("div[aria-haspopup='listbox']", { timeout: 10000 }).contains(10).click()
@@ -312,6 +318,7 @@ describe("unpublished folders, published folders, and user's draft templates pag
     cy.get("li[data-value='50']").click()
     cy.get("ul > a", { timeout: 10000 }).should("have.length", "50")
     cy.get("p", { timeout: 10000 }).contains("1-50 of 80").should("be.visible")
+    cy.get("[data-testid='page info']").contains("1 of 2 pages").should("be.visible")
   })
 
   it("should render user's draft templates correctly", () => {
@@ -401,8 +408,11 @@ describe("unpublished folders, published folders, and user's draft templates pag
     cy.get("h6").contains("Draft-study").click()
     cy.get("div[data-schema='draft-study'] > span").should("have.length", "10")
     cy.get("p").contains("1-10 of 15").should("be.visible")
-    cy.get("button[aria-label='Next page']").click()
+    cy.get("[data-testid='page info']").contains("1 of 2 pages").should("be.visible")
+
+    cy.get("button[aria-label='next page']").click()
     cy.get("p").contains("11-15 of 15").should("be.visible")
+    cy.get("[data-testid='page info']").contains("2 of 2 pages").should("be.visible")
     cy.get("div[aria-haspopup='listbox']", { timeout: 10000 }).contains(10).click()
     cy.get("li[data-value='15']").click()
     cy.get("div[data-schema='draft-study'] > span").should("have.length", "15")

--- a/src/__tests__/PublishedFoldersList.test.js
+++ b/src/__tests__/PublishedFoldersList.test.js
@@ -90,10 +90,10 @@ describe("Published folders list", () => {
     expect(itemsPerPageValue).toBeInTheDocument()
     expect(itemsPerPageValue).toHaveDisplayValue(10)
 
-    const previousPageButton = getByLabelText("Previous page")
+    const previousPageButton = getByLabelText("previous page")
     expect(previousPageButton).toBeVisible()
 
-    const nextPageButton = getByLabelText("Next page")
+    const nextPageButton = getByLabelText("next page")
     expect(nextPageButton).toBeVisible()
   })
 })

--- a/src/__tests__/UnpublishedFoldersList.test.js
+++ b/src/__tests__/UnpublishedFoldersList.test.js
@@ -79,10 +79,10 @@ describe("Unpublished folders list", () => {
     expect(itemsPerPageValue).toBeInTheDocument()
     expect(itemsPerPageValue).toHaveDisplayValue(10)
 
-    const previousPageButton = getByLabelText("Previous page")
+    const previousPageButton = getByLabelText("previous page")
     expect(previousPageButton).toBeVisible()
 
-    const nextPageButton = getByLabelText("Next page")
+    const nextPageButton = getByLabelText("next page")
     expect(nextPageButton).toBeVisible()
   })
 })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,10 +2,14 @@
 import React from "react"
 import type { Node } from "react"
 
+import IconButton from "@material-ui/core/IconButton"
+import { makeStyles, withStyles, useTheme } from "@material-ui/core/styles"
 import Table from "@material-ui/core/Table"
 import TableFooter from "@material-ui/core/TableFooter"
-import TablePagination from "@material-ui/core/TablePagination"
+import MUITablePagination from "@material-ui/core/TablePagination"
 import TableRow from "@material-ui/core/TableRow"
+import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft"
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight"
 import { useLocation } from "react-router-dom"
 
 import { ObjectTypes } from "constants/wizardObject"
@@ -76,6 +80,62 @@ export const getRowsPerPageOptions = (totalItems?: number): Array<any> => {
   return []
 }
 
+const TablePagination = withStyles({
+  spacer: {
+    flex: "none",
+  },
+  selectRoot: {
+    borderRight: "1px solid rgba(0, 0, 0, 0.87)",
+    marginRight: "0.5rem",
+    fontWeight: "bold",
+  },
+  select: { padding: 0 },
+  toolbar: {
+    display: "flex",
+    justifyContent: "flex-start",
+  },
+  actions: {
+    marginLeft: "auto",
+  },
+})(MUITablePagination)
+
+const tablePaginationStyles = makeStyles({
+  tablePagination: {
+    border: "none",
+  },
+  paginationActions: {
+    flexShrink: 0,
+    flexDirection: "row",
+    marginLeft: "auto",
+  },
+})
+
+const TablePaginationActions = ({ count, page, rowsPerPage, onPageChange }: any) => {
+  const theme = useTheme()
+  const classes = tablePaginationStyles()
+  const totalPages = Math.ceil(count / rowsPerPage)
+
+  const handleBackButtonClick = e => {
+    onPageChange(e, page - 1)
+  }
+  const handleNextButtonClick = e => {
+    onPageChange(e, page + 1)
+  }
+  return (
+    <div className={classes.paginationActions}>
+      <span aria-label="current page" data-testid="page info">
+        {page + 1} of {totalPages} pages
+      </span>
+      <IconButton onClick={handleBackButtonClick} disabled={page === 0} aria-label="previous page">
+        {theme.direction === "rtl" ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+      </IconButton>
+      <IconButton onClick={handleNextButtonClick} disabled={page >= totalPages - 1} aria-label="next page">
+        {theme.direction === "rtl" ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+      </IconButton>
+    </div>
+  )
+}
+
 // Pagination Component
 export const Pagination = ({
   totalNumberOfItems,
@@ -89,21 +149,26 @@ export const Pagination = ({
   itemsPerPage: number,
   handleChangePage: (e: any, page: number) => void,
   handleItemsPerPageChange: (e: any) => void,
-}): Node => (
-  <Table data-testid="table-pagination">
-    <TableFooter>
-      <TableRow>
-        <TablePagination
-          style={{ border: "none" }}
-          rowsPerPageOptions={getRowsPerPageOptions(totalNumberOfItems)}
-          count={totalNumberOfItems}
-          labelRowsPerPage="Items per page:"
-          page={page}
-          rowsPerPage={itemsPerPage}
-          onPageChange={handleChangePage}
-          onRowsPerPageChange={handleItemsPerPageChange}
-        />
-      </TableRow>
-    </TableFooter>
-  </Table>
-)
+}): Node => {
+  const classes = tablePaginationStyles()
+  return (
+    <Table data-testid="table-pagination">
+      <TableFooter>
+        <TableRow>
+          <TablePagination
+            className={classes.tablePagination}
+            ActionsComponent={TablePaginationActions}
+            count={totalNumberOfItems}
+            labelRowsPerPage="Items per page:"
+            labelDisplayedRows={({ from, to, count }) => `${from}-${to} of ${count} items`}
+            page={page}
+            rowsPerPage={itemsPerPage}
+            rowsPerPageOptions={getRowsPerPageOptions(totalNumberOfItems)}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleItemsPerPageChange}
+          />
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}


### PR DESCRIPTION
### Description

More clear separation between `Items` and `Pages` in pagination component.

### Related issues

Fix https://github.com/CSCfi/metadata-submitter-frontend/issues/422

### Type of change

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

- Move `Items` to the left and `Pages` to the right.
- Add more details for number of items and current page over total pages

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests
- [x] Integration Tests


