### PR TITLE
Show correct confirmation text before publishing folder

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -159,6 +159,7 @@ describe("Basic e2e", function () {
 
     // Navigate to publish
     cy.get("button[type=button]").contains("Publish").click()
+    cy.get("[data-testid='alert-dialog-content']").should("have.text", "Objects in this folder will be published.")
     cy.get('button[aria-label="Publish folder contents and move to frontpage"]').contains("Publish").click()
   })
 })

--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -57,6 +57,10 @@ describe("draft selections and templates", function () {
 
     // Navigate to publish button at the bottom
     cy.get("button[type=button]").contains("Publish").click()
+    cy.get("[data-testid='alert-dialog-content']").should(
+      "have.text",
+      "Objects in this folder will be published. Please choose the drafts you would like to save, unsaved drafts will be removed from this folder."
+    )
 
     // Select drafts inside the dialog
     cy.get("form").within(() => {

--- a/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardAlert.js
@@ -221,7 +221,9 @@ const CancelFormDialog = ({
         case "publish": {
           dialogTitle = "Publishing objects"
           dialogContent =
-            "Objects in this folder will be published. Please choose the drafts you would like to save, unsaved drafts will be removed from this folder."
+            submissionFolder?.drafts.length > 0
+              ? "Objects in this folder will be published. Please choose the drafts you would like to save, unsaved drafts will be removed from this folder."
+              : "Objects in this folder will be published."
           dialogActions = <WizardDraftSelections onHandleDialog={handleDialog} />
           break
         }
@@ -282,7 +284,9 @@ const CancelFormDialog = ({
     >
       <DialogTitle id="alert-dialog-title">{dialogTitle}</DialogTitle>
       <DialogContent>
-        <DialogContentText id="alert-dialog-description">{dialogContent}</DialogContentText>
+        <DialogContentText id="alert-dialog-description" data-testid="alert-dialog-content">
+          {dialogContent}
+        </DialogContentText>
       </DialogContent>
       {error && <ErrorMessage message={errorMessage} />}
       {dialogActions}


### PR DESCRIPTION
### Description

`Publish` **confirm dialog** should show correct instruction text to differentiate between having drafts to save as templates and having no drafts.

### Related issues

https://github.com/CSCfi/metadata-submitter-frontend/issues/428

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Showing different confirmation text in `WizardAlert` depends on the current folder has any drafts or not.

### Testing

- [x] Integration Tests



