### PR TITLE
Fix for deleting the draft only if the form is valid and submitted

### DIFF
--- a/cypress/integration/draft.spec.js
+++ b/cypress/integration/draft.spec.js
@@ -75,7 +75,7 @@ describe("Draft operations", function () {
 
     // Submit first form draft
     cy.continueFirstDraft()
-    cy.get("button[type=submit]").contains("Submit").click()
+    cy.get("button[type=submit]").contains("Submit", { force: true }).click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Submitted with")
     cy.get("ul[data-testid='Form-objects']").find("li").should("have.length", 1)
 

--- a/cypress/integration/editForm.spec.js
+++ b/cypress/integration/editForm.spec.js
@@ -202,4 +202,25 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("button[type=button]", { timeout: 10000 }).contains("Clear form").click()
     cy.get("[type='checkbox']").first().should("not.be.checked")
   })
+
+  it("should not remove the draft object when submitting invalid form", () => {
+    cy.clickFillForm("Sample")
+    cy.get("[data-testid='title']").type("Test sample title")
+    // Save draft
+    cy.get("button[type='button']").contains("Save as Draft").click()
+    // Edit the draft and try to submit invalid form
+    cy.continueFirstDraft()
+    cy.get("button[type=submit]").contains("Submit").click()
+    // Taxon field should be empty and the draft cannot be submitted yet
+    cy.get("[data-testid='sampleName.taxonId']").should("have.value", "")
+    cy.get("ul[data-testid='Draft-objects']").should("have.length", 1)
+
+    // Fill in taxonId and submit the form again
+    cy.get("[data-testid='sampleName.taxonId']").type("123")
+    cy.get("button[type=submit]").contains("Submit").click()
+
+    // Check that the draft is removed from the draft objects list and submitted
+    cy.get("ul[data-testid='Draft-objects']").should("have.length", 0)
+    cy.get("ul[data-testid='Form-objects']").should("have.length", 1)
+  })
 })

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -225,6 +225,16 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folder, curre
     checkDirty()
   }, [methods.formState.isDirty])
 
+  const { isSubmitSuccessful } = methods.formState // Check if the form has been successfully submitted without any errors
+
+  useEffect(() => {
+    // Delete draft form ONLY if the form was successfully submitted
+    if (isSubmitSuccessful) {
+      if (currentObject?.status === ObjectStatus.draft && currentObjectId && Object.keys(currentObject).length > 0)
+        handleDraftDelete(currentObjectId)
+    }
+  }, [isSubmitSuccessful])
+
   const handleCreateNewForm = () => {
     resetTimer()
     handleClearForm()
@@ -403,9 +413,6 @@ const FormContent = ({ resolver, formSchema, onSubmit, objectType, folder, curre
 
   const handleSubmitForm = () => {
     if (currentObject?.status === ObjectStatus.submitted) patchObject()
-    if (currentObject?.status === ObjectStatus.draft && currentObjectId && Object.keys(currentObject).length > 0)
-      handleDraftDelete(currentObjectId)
-
     resetTimer()
   }
 


### PR DESCRIPTION
### Description
Draft objects should not be removed from Draft object list if the form is submitted while it's still invalid.

### Related issues

Fixes https://github.com/CSCfi/metadata-submitter-frontend/issues/450

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Check if the form is submitted successfully and only by then we delete the draft object
- Update e2e test for this case

### Testing

- [x] Integration Tests

