### PR TITLE
Added support for ajv-i18n library

### DIFF
--- a/cypress/integration/fieldValidation.spec.js
+++ b/cypress/integration/fieldValidation.spec.js
@@ -1,0 +1,27 @@
+describe("Field validation", function () {
+  beforeEach(() => {
+    cy.login()
+  })
+
+  it("should translate AJV validation messages according to locale", () => {
+    cy.get("#lang-selector").should("contain", "en")
+
+    cy.get("button").contains("Create Submission").click()
+
+    cy.get("input[name='name']").type("Test published folder")
+    cy.get("textarea[name='description']").type("Test description")
+    cy.get("button[type=button]").contains("Next").click()
+    cy.wait(500)
+
+    cy.clickFillForm("Sample")
+
+    cy.get("input[name='sampleName.taxonId']").type("Test id").blur()
+    cy.get("p[id='sampleName.taxonId-helper-text']").should("have.text", "must be integer")
+
+    cy.get("#lang-selector").click()
+    cy.get("li[role=menuitem]").contains("Fi").click()
+
+    cy.get("input[name='sampleName.taxonId']").type(" edit").blur()
+    cy.get("p[id='sampleName.taxonId-helper-text']").should("have.text", "täytyy olla kokonaisluku")
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "metadata-submitter-frontend",
       "version": "0.11.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -17,6 +18,7 @@
         "@testing-library/react": "^12.1.2",
         "ajv": "^8.6.3",
         "ajv-formats": "^2.1.1",
+        "ajv-i18n": "^4.2.0",
         "apisauce": "^2.1.2",
         "i18next": "^21.4.0",
         "jest": "26.6.0",
@@ -3665,6 +3667,14 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
       }
     },
     "node_modules/alphanum-sort": {
@@ -25746,6 +25756,12 @@
       "requires": {
         "ajv": "^8.0.0"
       }
+    },
+    "ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^12.1.2",
     "ajv": "^8.6.3",
     "ajv-formats": "^2.1.1",
+    "ajv-i18n": "^4.2.0",
     "apisauce": "^2.1.2",
     "i18next": "^21.4.0",
     "jest": "26.6.0",

--- a/src/__tests__/FormValidation.test.js
+++ b/src/__tests__/FormValidation.test.js
@@ -28,7 +28,7 @@ const schema = {
 describe("Test form render by custom schema", () => {
   const onSubmit = jest.fn()
 
-  const resolver = WizardAjvResolver(schema)
+  const resolver = WizardAjvResolver(schema, "en")
 
   beforeEach(() => {
     const FormComponent = () => {

--- a/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardAjvResolver.js
@@ -4,6 +4,8 @@ import { appendErrors } from "react-hook-form"
 
 import JSONSchemaParser from "./WizardJSONSchemaParser"
 
+const localize = require("ajv-i18n")
+
 /*
  * Parse through ajv validation errors and transform them to errors readable by react-hook-form
  */
@@ -39,7 +41,7 @@ const parseErrorSchema = (validationError, validateAllFieldCriteria) =>
 /*
  * Resolver for checking if form data is valid against schema.
  */
-export const WizardAjvResolver = validationSchema => {
+export const WizardAjvResolver = (validationSchema, locale) => {
   if (!validationSchema) {
     throw new Error("Undefined schema, not able to validate")
   }
@@ -50,6 +52,15 @@ export const WizardAjvResolver = validationSchema => {
     const cleanedValues = JSONSchemaParser.cleanUpFormValues(values)
     const valid = validate(cleanedValues)
     if (!valid) {
+      switch (locale) {
+        case "fi": {
+          localize.fi(validate.errors)
+          break
+        }
+        default: {
+          localize.en(validate.errors)
+        }
+      }
       return {
         errors: parseErrorSchema(validate, false),
         values: {},

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -421,6 +421,7 @@ const WizardFillObjectDetailsForm = (): React$Element<typeof Container> => {
   const objectType = useSelector(state => state.objectType)
   const folder = useSelector(state => state.submissionFolder)
   const currentObject = useSelector(state => state.currentObject)
+  const locale = useSelector(state => state.locale)
 
   // States that will update in useEffect()
   const [states, setStates] = useState({
@@ -513,7 +514,7 @@ const WizardFillObjectDetailsForm = (): React$Element<typeof Container> => {
     <Container maxWidth={false} className={classes.container}>
       <FormContent
         formSchema={states.formSchema}
-        resolver={WizardAjvResolver(states.validationSchema)}
+        resolver={WizardAjvResolver(states.validationSchema, locale)}
         onSubmit={onSubmit}
         objectType={objectType}
         folder={folder}


### PR DESCRIPTION
### Description

Support locale based translations for AJV validation.
This PR requires Finnish translation to be contributed to [ajv-i18n](https://github.com/ajv-validator/ajv-i18n)

### Related issues

Closes #489 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Installed `ajv-i18n` package
- Pass locale to form resolver (`WizardAjvResolver`)
- Handle AJV translations by locale
- Proposed Finnish translations to [fork of ajv-i18n](https://github.com/CSCfi/ajv-i18n)

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
