### PR TITLE
Feature/enable draft update

### DIFF
--- a/cypress/integration/draftTemplates.spec.js
+++ b/cypress/integration/draftTemplates.spec.js
@@ -97,7 +97,7 @@ describe("draft selections and templates", function () {
       cy.get("h1", { timeout: 10000 }).contains("Sample").should("be.visible")
       cy.get("[data-testid='title']").should("have.value", "Sample draft title")
     }),
-    it("should be able to select and delete draft templates and reuse them when creating a new folder", () => {
+    it("should be able to select, edit and delete draft templates and reuse them when creating a new folder", () => {
       // Select drafts inside the dialog
       cy.get("form").within(() => {
         cy.get("input[type='checkbox']").first().check()
@@ -111,6 +111,28 @@ describe("draft selections and templates", function () {
       // Check if the drafts have been saved as user's templates in Home page
       cy.contains("Your Draft Templates", { timeout: 10000 }).should("be.visible")
 
+      // Edit template
+      cy.get("[data-testid='form-template-sample']").within(() => {
+        cy.get("button").first().click()
+      })
+
+      cy.get("[data-testid='edit-template']").click()
+
+      cy.get("[role='presentation']").within(() => {
+        cy.get("input[name='title']").should("be.visible")
+        cy.get("input[name='title']").type(" edit", { force: true })
+        cy.get("input[name='title']").should("have.value", "Sample draft title edit")
+
+        cy.get("button[type='submit']").click()
+      })
+
+      cy.get("div[role=alert]", { timeout: 10000 }).contains("Template updated with")
+
+      // Re-query template item
+      cy.get("[data-testid='template-sample-item']").first().as("firstSampleTemplate")
+      cy.get("@firstSampleTemplate").should("contain", "Sample draft title edit")
+
+      // Count sample templates, delete template and test that template count has decreased
       const listAllSampleTemplates = () => {
         cy.get("[data-testid='template-sample-item']")
           .its("length")
@@ -126,7 +148,6 @@ describe("draft selections and templates", function () {
 
       listAllSampleTemplates()
 
-      // Count sample templates, delete template and test that template count has decreased
       cy.get("[data-testid='template-sample-item']")
         .its("length")
         .then(lengthOfSampleTemplates => {
@@ -198,6 +219,7 @@ describe("draft selections and templates", function () {
       cy.get("button[type=button]").contains("Next").click()
 
       cy.wait(500)
+
       // Check that the new template is added as a draft
       cy.clickFillForm("Study")
       cy.get("[data-testid='Draft-objects']").children().should("have.length", 2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "metadata-submitter-frontend",
       "version": "0.11.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -5239,9 +5240,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -27003,9 +27004,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -72,9 +72,6 @@ const App = (): React$Element<typeof React.Fragment> => {
   const dispatch = useDispatch()
 
   const locale = useSelector(state => state.locale)
-  const statusDetails = useSelector(state =>
-    state.statusDetails ? JSON.parse(state.statusDetails) : state.statusDetails
-  )
 
   // Fetch array of schemas from backend and store it in frontend
   // Fetch only if the initial array is empty
@@ -197,13 +194,7 @@ const App = (): React$Element<typeof React.Fragment> => {
         </Route>
       </Switch>
       {/* Centralized status message handler */}
-      {statusDetails?.status === "asd" && !Array.isArray(statusDetails.response) && (
-        <StatusMessageHandler
-          status={statusDetails.status}
-          response={statusDetails.response}
-          helperText={statusDetails.helperText}
-        />
-      )}
+      <StatusMessageHandler />
     </React.Fragment>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -197,7 +197,7 @@ const App = (): React$Element<typeof React.Fragment> => {
         </Route>
       </Switch>
       {/* Centralized status message handler */}
-      {statusDetails?.status && !Array.isArray(statusDetails.response) && (
+      {statusDetails?.status === "asd" && !Array.isArray(statusDetails.response) && (
         <StatusMessageHandler
           status={statusDetails.status}
           response={statusDetails.response}

--- a/src/__tests__/StatusMessageHandler.test.js
+++ b/src/__tests__/StatusMessageHandler.test.js
@@ -11,13 +11,15 @@ import { ResponseStatus } from "constants/responseStatus"
 const mockStore = configureStore([])
 
 describe("StatusMessageHandler", () => {
-  const store = mockStore({
-    errorMessage: "",
-  })
-
   it("should render error message", () => {
     const responseMock = { data: { accessionId: "TESTID1234", status: 504 } }
     const helperTextMock = "Test prefix"
+
+    const store = mockStore({
+      // errorMessage: "",
+      statusDetails: { status: ResponseStatus.error, response: responseMock, helperText: helperTextMock },
+    })
+
     render(
       <Provider store={store}>
         <StatusMessageHandler status={ResponseStatus.error} response={responseMock} helperText={helperTextMock} />
@@ -28,6 +30,10 @@ describe("StatusMessageHandler", () => {
   })
 
   it("should render info message", () => {
+    const store = mockStore({
+      statusDetails: { status: ResponseStatus.info },
+    })
+
     render(
       <Provider store={store}>
         <StatusMessageHandler status={ResponseStatus.info} />
@@ -40,6 +46,11 @@ describe("StatusMessageHandler", () => {
 
   it("should render success message", () => {
     const responseMock = { data: { accessionId: "TESTID1234" }, config: { baseURL: "/drafts" } }
+
+    const store = mockStore({
+      statusDetails: { status: ResponseStatus.success, response: responseMock },
+    })
+
     render(
       <Provider store={store}>
         <StatusMessageHandler response={responseMock} status={ResponseStatus.success} />

--- a/src/components/Home/UserDraftTemplates.js
+++ b/src/components/Home/UserDraftTemplates.js
@@ -15,7 +15,6 @@ import { makeStyles } from "@material-ui/core/styles"
 import Typography from "@material-ui/core/Typography"
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp"
-import { useForm, FormProvider, useFormContext, Controller } from "react-hook-form"
 import { useSelector, useDispatch } from "react-redux"
 
 import UserDraftTemplateActions from "./UserDraftTemplateActions"
@@ -73,117 +72,94 @@ const UserDraftTemplates = (): React$Element<any> => {
   const dispatch = useDispatch()
   const templates = user.templates ? getUserTemplates(user.templates, objectTypesArray) : []
 
-  const methods = useForm()
-
-  const ConnectForm = ({ children }) => {
-    const methods = useFormContext()
-    return children({ ...methods })
-  }
-
   // Render when there is user's draft template(s)
   const DraftList = () => {
     const [checkedItems, setCheckedItems] = useState(templateAccessionIds)
 
-    const handleChange = () => {
-      const checkedItems = Object.values(methods.getValues()).filter(item => item)
-      setCheckedItems(checkedItems)
-      dispatch(setTemplateAccessionIds(checkedItems))
+    const handleChange = (accessionId: string) => {
+      let items = [...checkedItems]
+
+      checkedItems.find(item => item === accessionId)
+        ? (items = items.filter(item => item !== accessionId))
+        : items.push(accessionId)
+
+      setCheckedItems(items)
+      dispatch(setTemplateAccessionIds(items))
     }
 
-    return (
-      <FormProvider {...methods}>
-        <form onSubmit={methods.handleSubmit} onChange={handleChange} className={classes.form}>
-          <ConnectForm>
-            {({ register }) => {
-              return templates.map(draft => {
-                const schema = Object.keys(draft)[0]
-                const [open, setOpen] = useState(true)
-                // Control Pagination
-                const [page, setPage] = useState(0)
-                const [itemsPerPage, setItemsPerPage] = useState(10)
+    return templates.map(draft => {
+      const schema = Object.keys(draft)[0]
+      const [open, setOpen] = useState(true)
+      // Control Pagination
+      const [page, setPage] = useState(0)
+      const [itemsPerPage, setItemsPerPage] = useState(10)
 
-                const handleChangePage = (e: any, page: number) => {
-                  setPage(page)
-                }
+      const handleChangePage = (e: any, page: number) => {
+        setPage(page)
+      }
 
-                const handleItemsPerPageChange = (e: any) => {
-                  setItemsPerPage(e.target.value)
-                  setPage(0)
-                }
+      const handleItemsPerPageChange = (e: any) => {
+        setItemsPerPage(e.target.value)
+        setPage(0)
+      }
 
-                return (
-                  <FormControl key={schema} className={classes.formControl} data-testid={`form-${schema}`}>
-                    <FormLabel className={classes.formLabel} onClick={() => setOpen(!open)}>
-                      <Typography display="inline" variant="subtitle1" color="textPrimary">
-                        {formatDisplayObjectType(schema)}
-                      </Typography>
-                      {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-                    </FormLabel>
+      return (
+        <FormControl key={schema} className={classes.formControl} data-testid={`form-${schema}`}>
+          <FormLabel className={classes.formLabel} onClick={() => setOpen(!open)}>
+            <Typography display="inline" variant="subtitle1" color="textPrimary">
+              {formatDisplayObjectType(schema)}
+            </Typography>
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </FormLabel>
 
-                    <Collapse className={classes.collapse} in={open} timeout={{ enter: 150, exit: 150 }} unmountOnExit>
-                      <Controller
-                        name={"Collapse"}
-                        render={() => {
-                          return draft[schema]
-                            .slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage)
-                            .map(item => {
-                              const { ref, ...rest } = register(item.accessionId)
-                              return (
-                                <Grid
-                                  container
-                                  key={item.accessionId}
-                                  className={classes.formControlLabel}
-                                  data-testid={`${item.schema}-item`}
-                                >
-                                  <Grid item xs>
-                                    <FormControlLabel
-                                      control={
-                                        <Checkbox
-                                          checked={
-                                            checkedItems.find(element => element === item.accessionId) !== undefined
-                                          }
-                                          color="primary"
-                                          name={item.accessionId}
-                                          value={item.accessionId}
-                                          inputRef={ref}
-                                          {...rest}
-                                        />
-                                      }
-                                      label={
-                                        <ListItemText
-                                          className={classes.listItemText}
-                                          primary={getItemPrimaryText(item)}
-                                          secondary={item.accessionId}
-                                          data-schema={item.schema}
-                                        />
-                                      }
-                                    />
-                                  </Grid>
-                                  <Grid item xs="auto">
-                                    <UserDraftTemplateActions item={item} />
-                                  </Grid>
-                                </Grid>
-                              )
-                            })
-                        }}
-                      />
+          <Collapse className={classes.collapse} in={open} timeout={{ enter: 150, exit: 150 }} unmountOnExit>
+            {draft[schema].slice(page * itemsPerPage, page * itemsPerPage + itemsPerPage).map(item => {
+              return (
+                <Grid
+                  container
+                  key={item.accessionId}
+                  className={classes.formControlLabel}
+                  data-testid={`${item.schema}-item`}
+                >
+                  <Grid item xs>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={checkedItems.find(element => element === item.accessionId) !== undefined}
+                          onClick={() => handleChange(item.accessionId)}
+                          color="primary"
+                          name={item.accessionId}
+                          value={item.accessionId}
+                        />
+                      }
+                      label={
+                        <ListItemText
+                          className={classes.listItemText}
+                          primary={getItemPrimaryText(item)}
+                          secondary={item.accessionId}
+                          data-schema={item.schema}
+                        />
+                      }
+                    />
+                  </Grid>
+                  <Grid item xs="auto">
+                    <UserDraftTemplateActions item={item} />
+                  </Grid>
+                </Grid>
+              )
+            })}
 
-                      <Pagination
-                        totalNumberOfItems={draft[schema].length}
-                        page={page}
-                        itemsPerPage={itemsPerPage}
-                        handleChangePage={handleChangePage}
-                        handleItemsPerPageChange={handleItemsPerPageChange}
-                      />
-                    </Collapse>
-                  </FormControl>
-                )
-              })
-            }}
-          </ConnectForm>
-        </form>
-      </FormProvider>
-    )
+            <Pagination
+              totalNumberOfItems={draft[schema].length}
+              page={page}
+              itemsPerPage={itemsPerPage}
+              handleChangePage={handleChangePage}
+              handleItemsPerPageChange={handleItemsPerPageChange}
+            />
+          </Collapse>
+        </FormControl>
+      )
+    })
   }
 
   // Renders when user has no draft templates

--- a/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardFillObjectDetailsForm.js
@@ -180,8 +180,8 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
         root: classes.cardHeader,
         action: classes.cardHeaderAction,
       }}
-      className={currentObject.status === ObjectStatus.template ? classes.resetTopMargin : null}
-      action={currentObject.status === ObjectStatus.template ? templateButtonGroup : buttonGroup}
+      className={currentObject?.status === ObjectStatus.template ? classes.resetTopMargin : null}
+      action={currentObject?.status === ObjectStatus.template ? templateButtonGroup : buttonGroup}
     />
   )
 }
@@ -330,7 +330,7 @@ const FormContent = ({
     resetTimer()
 
     // Prevent auto save from template dialog
-    if (currentObject.status !== ObjectStatus.template) startTimer()
+    if (currentObject?.status !== ObjectStatus.template) startTimer()
   }
 
   useEffect(() => {
@@ -382,7 +382,6 @@ const FormContent = ({
     dispatch(
       updateStatus({
         status: ResponseStatus.info,
-        response: "",
         helperText: "An empty form cannot be saved. Please fill in the form before saving it.",
       })
     )
@@ -393,9 +392,6 @@ const FormContent = ({
 
     if (checkFormCleanedValuesEmpty(cleanedValues)) {
       const response = await templateAPI.patchTemplateFromJSON(objectType, currentObject.accessionId, cleanedValues)
-
-      // closeDialog()
-      // console.log(response)
 
       if (response.ok) {
         dispatch(
@@ -499,7 +495,7 @@ const FormContent = ({
 /*
  * Container for json schema based form. Handles json schema loading, form rendering, form submitting and error/success alerts.
  */
-const WizardFillObjectDetailsForm = (props: { closeDialog: () => void }): React$Element<typeof Container> => {
+const WizardFillObjectDetailsForm = (props: { closeDialog?: () => void }): React$Element<typeof Container> => {
   const { closeDialog } = props
   const classes = useStyles()
   const dispatch = useDispatch()
@@ -606,7 +602,7 @@ const WizardFillObjectDetailsForm = (props: { closeDialog: () => void }): React$
         folder={folder}
         currentObject={currentObject}
         key={currentObject?.accessionId || folder.folderId}
-        closeDialog={closeDialog}
+        closeDialog={closeDialog || (() => {})}
       />
       {submitting && <LinearProgress />}
     </Container>

--- a/src/components/NewDraftWizard/WizardHooks/WizardSubmitObjectHook.js
+++ b/src/components/NewDraftWizard/WizardHooks/WizardSubmitObjectHook.js
@@ -18,7 +18,6 @@ const submitObjectHook = async (formData: any, folderId: string, objectType: str
     dispatch(
       updateStatus({
         status: ResponseStatus.info,
-        response: {},
         helperText: "",
       })
     )

--- a/src/components/StatusMessageHandler.js
+++ b/src/components/StatusMessageHandler.js
@@ -169,7 +169,9 @@ const StatusMessageHandler = (): React$Element<any> => {
       {statusDetails?.status && !Array.isArray(statusDetails.response) && (
         <Message
           status={statusDetails.status}
-          response={statusDetails.response}
+          response={
+            typeof statusDetails.response === "string" ? JSON.parse(statusDetails.response) : statusDetails.response
+          }
           helperText={statusDetails.helperText}
         />
       )}

--- a/src/components/StatusMessageHandler.js
+++ b/src/components/StatusMessageHandler.js
@@ -1,10 +1,10 @@
 //@flow
 import React, { useState } from "react"
 
-import Portal from "@material-ui/core/Portal"
+// import Portal from "@material-ui/core/Portal"
 import Snackbar from "@material-ui/core/Snackbar"
 import Alert from "@material-ui/lab/Alert"
-import { useDispatch } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
 
 import { ResponseStatus } from "constants/responseStatus"
 import { resetStatusDetails } from "features/statusMessageSlice"
@@ -123,7 +123,7 @@ const SuccessHandler = ({
   )
 }
 
-const StatusMessageHandler = ({
+const Message = ({
   status,
   response,
   helperText,
@@ -155,11 +155,25 @@ const StatusMessageHandler = ({
   }
 
   return (
-    <Portal>
-      <Snackbar autoHideDuration={autoHideDuration} open={open} onClose={() => handleClose()}>
-        {messageTemplate(status)}
-      </Snackbar>
-    </Portal>
+    <Snackbar autoHideDuration={autoHideDuration} open={open} onClose={() => handleClose()}>
+      {messageTemplate(status)}
+    </Snackbar>
+  )
+}
+
+const StatusMessageHandler = (): React$Element<any> => {
+  const statusDetails = useSelector(state => state.statusDetails)
+
+  return (
+    <React.Fragment>
+      {statusDetails?.status && !Array.isArray(statusDetails.response) && (
+        <Message
+          status={statusDetails.status}
+          response={statusDetails.response}
+          helperText={statusDetails.helperText}
+        />
+      )}
+    </React.Fragment>
   )
 }
 

--- a/src/components/StatusMessageHandler.js
+++ b/src/components/StatusMessageHandler.js
@@ -1,6 +1,7 @@
 //@flow
 import React, { useState } from "react"
 
+import Portal from "@material-ui/core/Portal"
 import Snackbar from "@material-ui/core/Snackbar"
 import Alert from "@material-ui/lab/Alert"
 import { useDispatch } from "react-redux"
@@ -101,6 +102,14 @@ const SuccessHandler = ({
             message = `Submitted with accessionid ${response.data.accessionId}`
           }
         }
+        break
+      }
+      case "/templates": {
+        switch (response.config.method) {
+          default: {
+            message = `Template updated with accessionid ${response.data.accessionId}`
+          }
+        }
       }
     }
   } else {
@@ -146,9 +155,11 @@ const StatusMessageHandler = ({
   }
 
   return (
-    <Snackbar autoHideDuration={autoHideDuration} open={open} onClose={() => handleClose()}>
-      {messageTemplate(status)}
-    </Snackbar>
+    <Portal>
+      <Snackbar autoHideDuration={autoHideDuration} open={open} onClose={() => handleClose()}>
+        {messageTemplate(status)}
+      </Snackbar>
+    </Portal>
   )
 }
 

--- a/src/constants/wizardObject.js
+++ b/src/constants/wizardObject.js
@@ -23,6 +23,7 @@ export const DisplayObjectTypes = {
 export const ObjectStatus = {
   draft: "Draft",
   submitted: "Submitted",
+  template: "Template",
 }
 
 export const ObjectSubmissionTypes = {

--- a/src/features/statusMessageSlice.js
+++ b/src/features/statusMessageSlice.js
@@ -1,7 +1,7 @@
 //@flow
 import { createSlice } from "@reduxjs/toolkit"
 
-import type { StatusDetails, Response } from "types"
+import type { StatusDetails } from "types"
 
 const initialState: null | StatusDetails = null
 
@@ -19,18 +19,9 @@ export default statusMessageSlice.reducer
 export const updateStatus =
   (statusDetails: StatusDetails): ((dispatch: (any) => void) => Promise<void>) =>
   async (dispatch: any => void) => {
-    const response = statusDetails.response || {}
-
-    const statusResponse: Response = {
-      config: { baseURL: response.config.baseURL, method: response.config.method },
-      data: response.data,
-      ok: response.ok,
-      status: response.status,
-    }
-
     const details: StatusDetails = {
       status: statusDetails.status,
-      response: statusResponse,
+      response: JSON.stringify(statusDetails.response),
       helperText: statusDetails.helperText,
     }
 

--- a/src/features/statusMessageSlice.js
+++ b/src/features/statusMessageSlice.js
@@ -1,7 +1,9 @@
 //@flow
 import { createSlice } from "@reduxjs/toolkit"
 
-const initialState = null
+import type { StatusDetails, Response } from "types"
+
+const initialState: null | StatusDetails = null
 
 const statusMessageSlice: any = createSlice({
   name: "wizardStatusMessage",
@@ -14,14 +16,23 @@ const statusMessageSlice: any = createSlice({
 export const { setStatusDetails, resetStatusDetails } = statusMessageSlice.actions
 export default statusMessageSlice.reducer
 
-type StatusDetails = {
-  status: string,
-  response?: Object,
-  helperText?: string,
-}
-
 export const updateStatus =
   (statusDetails: StatusDetails): ((dispatch: (any) => void) => Promise<void>) =>
   async (dispatch: any => void) => {
-    dispatch(setStatusDetails(JSON.stringify(statusDetails)))
+    const response = statusDetails.response || {}
+
+    const statusResponse: Response = {
+      config: { baseURL: response.config.baseURL, method: response.config.method },
+      data: response.data,
+      ok: response.ok,
+      status: response.status,
+    }
+
+    const details: StatusDetails = {
+      status: statusDetails.status,
+      response: statusResponse,
+      helperText: statusDetails.helperText,
+    }
+
+    dispatch(setStatusDetails(details))
   }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -19,6 +19,10 @@ const userSlice: any = createSlice({
   initialState,
   reducers: {
     setUser: (state, action) => action.payload,
+    updateTemplateDisplayTitle: (state, action) => {
+      state.templates.find(item => item.accessionId === action.payload.accessionId).tags.displayTitle =
+        action.payload.displayTitle
+    },
     deleteTemplateByAccessionId: (state, action) => {
       state.templates = _reject(state.templates, template => {
         return template.accessionId === action.payload
@@ -28,7 +32,7 @@ const userSlice: any = createSlice({
   },
 })
 
-export const { setUser, resetUser, deleteTemplateByAccessionId } = userSlice.actions
+export const { setUser, resetUser, updateTemplateDisplayTitle, deleteTemplateByAccessionId } = userSlice.actions
 export default userSlice.reducer
 
 export const fetchUserById =
@@ -60,6 +64,24 @@ export const addDraftsToUser =
 
     return new Promise((resolve, reject) => {
       if (response.ok) {
+        resolve(response)
+      } else {
+        reject(JSON.stringify(response))
+      }
+    })
+  }
+
+export const replaceTemplate =
+  (index: number, displayTitle: string, accessionId: string): ((dispatch: (any) => void) => Promise<any>) =>
+  async (dispatch: any => void) => {
+    const tags: { displayTitle: string } = { displayTitle: displayTitle }
+
+    const changes = [{ op: "replace", path: `/templates/${index}/tags`, value: tags }]
+    const response = await userAPIService.patchUserById("current", changes)
+
+    return new Promise((resolve, reject) => {
+      if (response.ok) {
+        dispatch(updateTemplateDisplayTitle({ accessionId: accessionId, displayTitle: displayTitle }))
         resolve(response)
       } else {
         reject(JSON.stringify(response))

--- a/src/services/templateAPI.js
+++ b/src/services/templateAPI.js
@@ -1,10 +1,10 @@
 //@flow
 import { create } from "apisauce"
-// import { omit } from "lodash"
+import { omit } from "lodash"
 
 import { errorMonitor } from "./errorMonitor"
 
-// import { OmitObjectValues } from "constants/wizardObject"
+import { OmitObjectValues } from "constants/wizardObject"
 
 const api = create({ baseURL: "/templates" })
 api.addMonitor(errorMonitor)
@@ -17,6 +17,10 @@ const getTemplateByAccessionId = async (objectType: string, accessionId: string)
   return await api.get(`/${objectType}/${accessionId}`)
 }
 
+const patchTemplateFromJSON = async (objectType: string, accessionId: any, JSONContent: any): Promise<any> => {
+  return await api.patch(`/${objectType}/${accessionId}`, omit(JSONContent, OmitObjectValues))
+}
+
 const deleteTemplateByAccessionId = async (objectType: string, accessionId: string): Promise<any> => {
   return await api.delete(`/${objectType}/${accessionId}`)
 }
@@ -24,5 +28,6 @@ const deleteTemplateByAccessionId = async (objectType: string, accessionId: stri
 export default {
   createTemplatesFromJSON,
   getTemplateByAccessionId,
+  patchTemplateFromJSON,
   deleteTemplateByAccessionId,
 }

--- a/src/services/templateAPI.js
+++ b/src/services/templateAPI.js
@@ -5,6 +5,7 @@ import { omit } from "lodash"
 import { errorMonitor } from "./errorMonitor"
 
 import { OmitObjectValues } from "constants/wizardObject"
+import { getObjectDisplayTitle } from "utils"
 
 const api = create({ baseURL: "/templates" })
 api.addMonitor(errorMonitor)
@@ -18,7 +19,8 @@ const getTemplateByAccessionId = async (objectType: string, accessionId: string)
 }
 
 const patchTemplateFromJSON = async (objectType: string, accessionId: any, JSONContent: any): Promise<any> => {
-  return await api.patch(`/${objectType}/${accessionId}`, omit(JSONContent, OmitObjectValues))
+  const draftTags = { tags: { displayTitle: getObjectDisplayTitle(objectType, JSONContent) } }
+  return await api.patch(`/${objectType}/${accessionId}`, { ...omit(JSONContent, OmitObjectValues), draftTags })
 }
 
 const deleteTemplateByAccessionId = async (objectType: string, accessionId: string): Promise<any> => {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -46,3 +46,16 @@ export type FolderDataFromForm = {
 }
 
 export type CreateFolderFormRef = ElementRef<typeof useForm>
+
+export type Response = {
+  config: { baseURL: string, method: string },
+  data: any,
+  ok: boolean,
+  status: number,
+}
+
+export type StatusDetails = {
+  status: string,
+  response?: Response,
+  helperText?: string,
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -47,15 +47,8 @@ export type FolderDataFromForm = {
 
 export type CreateFolderFormRef = ElementRef<typeof useForm>
 
-export type Response = {
-  config: { baseURL: string, method: string },
-  data: any,
-  ok: boolean,
-  status: number,
-}
-
 export type StatusDetails = {
   status: string,
-  response?: Response,
+  response?: any,
   helperText?: string,
 }


### PR DESCRIPTION
### Description

Added option for user to update saved templates.

### Related issues

Closes #488

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Template menu action for edit functionality
- Simplified templates list rendering (previous version caused nested <form> tags with form dialog)
- Option for rendering `WizardFillObjectDetailsForm` component in a dialog
- Form actions for template -typed object
- Reset draftStatus and currentObject redux state objects on form component unmount
- Handle template replace both into backend and redux state
- Prevent re-render of app by moving status message handling rendering logic to message handler from app root
- Serialize status message details
- Updated status message handler tests
- Added test for template edit

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
