### PR TITLE
Feature/autocomplete full name

### DIFF
--- a/cypress/integration/doiForm.spec.js
+++ b/cypress/integration/doiForm.spec.js
@@ -97,9 +97,10 @@ describe("DOI form", function () {
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
 
     // Go to DOI form
-    cy.get("button[type=button]").contains("Next").click()
-    cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
-    cy.get("div[role='dialog']").should("be.visible")
+    cy.openDOIForm()
+    // cy.get("button[type=button]").contains("Next").click()
+    // cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
+    // cy.get("div[role='dialog']").should("be.visible")
 
     // Check file types from submitted Run form and Analysis form are Uniquely pre-filled in DOI form
     cy.get("input[data-testid='formats.0']", { timeout: 10000 }).should("have.value", "bam")
@@ -194,9 +195,7 @@ describe("DOI form", function () {
   }),
     it("should fill the required fields and save DOI form successfully", () => {
       // Go to DOI form
-      cy.get("button[type=button]").contains("Next").click()
-      cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
-      cy.get("div[role='dialog']").should("be.visible")
+      cy.openDOIForm()
 
       // Fill in required Creators field
       cy.get("h2[data-testid='creators']").parent().children("button").click()
@@ -213,5 +212,25 @@ describe("DOI form", function () {
       cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
       cy.get("input[data-testid='creators.0.givenName']").should("have.value", "John Smith")
       cy.get("select[name='subjects.0.subject']").should("have.value", "FOS: Mathematics")
+    }),
+    it("should autofill full name based on family and given name", () => {
+      // Go to DOI form
+      cy.openDOIForm()
+      // Go to Creators section and fill in given name, family name
+      cy.get("h2[data-testid='creators']").parents().children("button").click()
+      cy.get("input[data-testid='creators.0.givenName']").type("Creator's given name")
+      cy.get("input[data-testid='creators.0.familyName']").type("Creator's family name")
+      // Check full name is autofilled from family name and given name
+      cy.get("input[data-testid='creators.0.name']").should("have.value", "Creator's family name,Creator's given name")
+
+      // Go to Contributors and fill in given name, family name
+      cy.get("h2[data-testid='contributors']").parents().children("button").click()
+      cy.get("input[data-testid='contributors.0.givenName']").type("Contributor's given name")
+      cy.get("input[data-testid='contributors.0.familyName']").type("Contributor's family name")
+      // Check full name is autofilled from family name and given name
+      cy.get("input[data-testid='contributors.0.name']").should(
+        "have.value",
+        "Contributor's family name,Contributor's given name"
+      )
     })
 })

--- a/cypress/integration/doiForm.spec.js
+++ b/cypress/integration/doiForm.spec.js
@@ -98,9 +98,6 @@ describe("DOI form", function () {
 
     // Go to DOI form
     cy.openDOIForm()
-    // cy.get("button[type=button]").contains("Next").click()
-    // cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
-    // cy.get("div[role='dialog']").should("be.visible")
 
     // Check file types from submitted Run form and Analysis form are Uniquely pre-filled in DOI form
     cy.get("input[data-testid='formats.0']", { timeout: 10000 }).should("have.value", "bam")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -91,3 +91,10 @@ Cypress.Commands.add("findDraftFolder", label => {
     }
   })
 })
+
+// Go to DOI form
+Cypress.Commands.add("openDOIForm", () => {
+  cy.get("button[type=button]").contains("Next").click()
+  cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
+  cy.get("div[role='dialog']").should("be.visible")
+})

--- a/src/components/NewDraftWizard/WizardForms/WizardDOIForm.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardDOIForm.js
@@ -27,6 +27,7 @@ const DOIForm = ({ formId }: { formId: string }): React$Element<typeof FormProvi
   const [dataciteSchema, setDataciteSchema] = useState({})
 
   useEffect(() => {
+    let isMounted = true
     const getDataciteSchema = async () => {
       let dataciteSchema = sessionStorage.getItem(`cached_datacite_schema`)
       if (!dataciteSchema || !new Ajv().validateSchema(JSON.parse(dataciteSchema))) {
@@ -47,9 +48,14 @@ const DOIForm = ({ formId }: { formId: string }): React$Element<typeof FormProvi
         dataciteSchema = JSON.parse(dataciteSchema)
       }
       const dereferencedDataciteSchema = await dereferenceSchema(dataciteSchema)
-      setDataciteSchema(dereferencedDataciteSchema)
+      if (isMounted) {
+        setDataciteSchema(dereferencedDataciteSchema)
+      }
     }
     getDataciteSchema()
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   const currentFolder = useSelector(state => state.submissionFolder)

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.js
@@ -605,16 +605,16 @@ const FormTextField = ({
     // check changes of value of autocompleteField from watchValues
     prefilledValue = watchAutocompleteFieldName ? get(watchValues, watchAutocompleteFieldName) : null
 
-    // If it's <creators>'s and <contributors>'s FullName field, watch the values of GivenName and LastName
+    // If it's <creators>'s and <contributors>'s FullName field, watch the values of GivenName and FamilyName
     const isFullNameField = (path[0] === "creators" || path[0] === "contributors") && path[2] === "name"
 
     if (isFullNameField) {
       const givenName = getPathName(path, "givenName")
       const givenNameValue = get(watchValues, givenName) || ""
-      const lastName = getPathName(path, "familyName")
-      const lastNameValue = get(watchValues, lastName)?.length > 0 ? get(watchValues, lastName).concat(",") : ""
+      const familyName = getPathName(path, "familyName")
+      const familyNameValue = get(watchValues, familyName)?.length > 0 ? get(watchValues, familyName).concat(",") : ""
       // Return value for FullName field
-      fullNameValue = `${lastNameValue}${givenNameValue}`
+      fullNameValue = `${familyNameValue}${givenNameValue}`
     }
 
     // Conditions to disable input field: disable editing option if the field is rendered as prefilled

--- a/src/utils/JSONSchemaUtils.js
+++ b/src/utils/JSONSchemaUtils.js
@@ -17,6 +17,14 @@ export const dereferenceSchema = async (schema: any): Promise<any> => {
 export const pathToName = (path: string[]): string => path.join(".")
 
 /*
+ * Get pathName for a specific field based on the pathName of another field (only different in the last element)
+ */
+export const getPathName = (path: Array<string>, field: string): string => {
+  const pathName = path.slice(0, -1).join(".").concat(".", field)
+  return pathName
+}
+
+/*
  * Parse initial values from given object
  */
 export const traverseValues = (object: any): any => {


### PR DESCRIPTION
### Description

In DOI form, `creators`' and `contritbutors`' *full name* should be autofilled from *last name* and *given name*

### Related issues

Closes https://github.com/CSCfi/metadata-submitter-frontend/issues/501

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
- `watch` changes from `lastName` and `givenName` fields to fill in the `fullName`
- Disable the field `fullName`
- Add `getPathName` function to be reused to `JSONSchemaUtils`
- Update cypress test for autofilling `fullName`

### Testing

- [x] Unit Tests


