### PR TITLE
Handle draft wizard routes with folder id as URL parameter

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -67,7 +67,7 @@ describe("Home e2e", function () {
     cy.get("tr[data-testid='Second test title']").within(() => cy.get('button[aria-label="Edit this object"]').click())
     cy.get("select[name='descriptor.studyType']").select("Metagenomics")
     cy.get("button[type=submit]").contains("Submit").click()
-    cy.get(".MuiListItem-container", { timeout: 30000 }).should("have.length", 2)
+    cy.get(".MuiListItem-container", { timeout: 30000 }).should("have.length", 1)
     cy.wait(500)
     // Navigate to summary
     cy.get("button[type=button]").contains("Next", { timeout: 10000 }).click()

--- a/src/App.js
+++ b/src/App.js
@@ -136,6 +136,12 @@ const App = (): React$Element<typeof React.Fragment> => {
     return `/:locale/${path}`
   }
 
+  const newDraftElement = (
+    <Container component="main" maxWidth={false} className={classes.wizardContent}>
+      <NewDraftWizard />
+    </Container>
+  )
+
   return (
     <React.Fragment>
       <CssBaseline />
@@ -190,14 +196,10 @@ const App = (): React$Element<typeof React.Fragment> => {
             </Container>
           }
         />
-        <Route
-          path={setPath("newdraft")}
-          element={
-            <Container component="main" maxWidth={false} className={classes.wizardContent}>
-              <NewDraftWizard />
-            </Container>
-          }
-        />
+        <Route path={setPath("newdraft")}>
+          <Route path=":folderId" element={newDraftElement} />
+          <Route path="" element={newDraftElement} />
+        </Route>
         <Route path="/error401" element={<Page401 />} />
         <Route path="/error403" element={<Page403 />} />
         <Route path="/error500" element={<Page500 />} />

--- a/src/__tests__/NewDraftWizard.test.js
+++ b/src/__tests__/NewDraftWizard.test.js
@@ -2,7 +2,9 @@ import React from "react"
 
 import "@testing-library/jest-dom/extend-expect"
 import { ThemeProvider } from "@material-ui/core/styles"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitForElementToBeRemoved } from "@testing-library/react"
+import { rest } from "msw"
+import { setupServer } from "msw/node"
 import { Provider } from "react-redux"
 import { MemoryRouter } from "react-router-dom"
 import configureStore from "redux-mock-store"
@@ -15,7 +17,13 @@ import App from "App"
 const middlewares = [thunk]
 const mockStore = configureStore(middlewares)
 
+const server = setupServer()
+
 describe("NewDraftWizard", () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
   it("should navigate to 404 page on undefined step", () => {
     const store = mockStore({})
     render(
@@ -29,5 +37,87 @@ describe("NewDraftWizard", () => {
     )
     screen.getByText("404 Not Found")
     expect(screen.getByText("404 Not Found")).toBeInTheDocument()
+  })
+
+  it("should redirect back to draft wizard start on invalid folderId", async () => {
+    server.use(
+      rest.get("/folders/:folderId", (req, res, ctx) => {
+        const { folderId } = req.params
+        return res(res => {
+          res.status = 404
+          return ctx.json({
+            type: "about:blank",
+            title: "Not Found",
+            detail: `Folder with id ${folderId} was not found.`,
+            instance: `/folders/${folderId}`,
+          })
+        })
+      })
+    )
+
+    const store = mockStore({
+      objectType: "",
+      submissionType: "",
+      submissionFolder: { metaDataObjects: [] },
+      objectTypesArray: ["study"],
+    })
+    render(
+      <MemoryRouter initialEntries={[{ pathname: "/en/newdraft/123456", search: "?step=1" }]}>
+        <Provider store={store}>
+          <ThemeProvider theme={CSCtheme}>
+            <App />
+          </ThemeProvider>
+        </Provider>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(() => screen.getByRole("progressbar"))
+    expect(screen.getByTestId("folderName")).toBeInTheDocument()
+  })
+
+  it("should render folder by folderId in URL parameters", async () => {
+    const folderId = "123456"
+    const folderName = "Folder name"
+    const folderDescription = "Folder description"
+
+    server.use(
+      rest.get("/folders/:folderId", (req, res, ctx) => {
+        const { folderId } = req.params
+        return res(
+          ctx.json({
+            name: folderName,
+            description: folderDescription,
+            folderId: folderId,
+          })
+        )
+      })
+    )
+
+    const store = mockStore({
+      objectType: "",
+      submissionType: "",
+      submissionFolder: {
+        name: folderName,
+        folderDescription: folderDescription,
+        published: false,
+        metadataObjects: [],
+        drafts: [],
+        folderId: folderId,
+      },
+      objectTypesArray: ["study"],
+    })
+    render(
+      <MemoryRouter initialEntries={[{ pathname: `/en/newdraft/${folderId}`, search: "?step=0" }]}>
+        <Provider store={store}>
+          <ThemeProvider theme={CSCtheme}>
+            <App />
+          </ThemeProvider>
+        </Provider>
+      </MemoryRouter>
+    )
+
+    await waitForElementToBeRemoved(() => screen.getByRole("progressbar"))
+    const folderNameInput = screen.getByTestId("folderName")
+    expect(folderNameInput).toHaveValue(folderName)
   })
 })

--- a/src/components/Home/SelectedFolderDetails.js
+++ b/src/components/Home/SelectedFolderDetails.js
@@ -138,7 +138,10 @@ const SelectedFolderDetails = (): React$Element<typeof Grid> => {
 
   const handleEditFolder = (step: number) => {
     dispatch(setFolder(selectedFolder.originalFolderData))
-    navigate({ pathname: pathWithLocale("newdraft"), search: `step=${step}` })
+    navigate({
+      pathname: pathWithLocale(`newdraft/${selectedFolder.originalFolderData.folderId}`),
+      search: `step=${step}`,
+    })
   }
 
   const handlePublishFolder = () => {
@@ -191,7 +194,7 @@ const SelectedFolderDetails = (): React$Element<typeof Grid> => {
       dispatch(setSubmissionType(submissionType))
       dispatch(setObjectType(objectType))
       dispatch(setFolder(selectedFolder.originalFolderData))
-      navigate({ pathname: pathWithLocale("newdraft"), search: `step=1` })
+      navigate({ pathname: pathWithLocale(`newdraft/${folderId}`), search: `step=1` })
     } else {
       dispatch(
         updateStatus({

--- a/src/components/NewDraftWizard/WizardComponents/WizardStepper.js
+++ b/src/components/NewDraftWizard/WizardComponents/WizardStepper.js
@@ -12,7 +12,7 @@ import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos"
 import Check from "@material-ui/icons/Check"
 import clsx from "clsx"
 import { useDispatch, useSelector } from "react-redux"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 
 import WizardAlert from "./WizardAlert"
 
@@ -131,6 +131,10 @@ const WizardStepper = ({ createFolderFormRef }: { createFolderFormRef?: CreateFo
   const [direction, setDirection] = useState("")
   const draftStatus = useSelector(state => state.draftStatus)
   const navigate = useNavigate()
+  const params = useParams()
+
+  const folderId = params.folderId
+  const newDraftPath = pathWithLocale(`newdraft/${folderId}`)
 
   const queryParams = useQuery()
   const wizardStep = Number(queryParams.get("step"))
@@ -143,7 +147,7 @@ const WizardStepper = ({ createFolderFormRef }: { createFolderFormRef?: CreateFo
     dispatch(resetDraftStatus())
 
     if (step) {
-      direction === "previous" ? navigate(-1) : navigate({ pathName: pathWithLocale("newdraft"), search: "step=2" })
+      direction === "previous" ? navigate(-1) : navigate({ pathname: newDraftPath, search: "step=2" })
       dispatch(resetObjectType())
       dispatch(resetSubmissionType())
     }
@@ -162,7 +166,7 @@ const WizardStepper = ({ createFolderFormRef }: { createFolderFormRef?: CreateFo
             setDirection("previous")
             setAlert(true)
           } else {
-            navigate({ pathName: pathWithLocale("newdraft"), search: `step=${wizardStep - 1}` })
+            navigate({ pathname: newDraftPath, search: `step=${wizardStep - 1}` })
           }
         }}
       >
@@ -195,7 +199,7 @@ const WizardStepper = ({ createFolderFormRef }: { createFolderFormRef?: CreateFo
             setDirection("next")
             setAlert(true)
           } else if (wizardStep !== 2 && !createFolderFormRef?.current) {
-            navigate({ pathName: pathWithLocale("newdraft"), search: "step=2" })
+            navigate({ pathname: newDraftPath, search: "step=2" })
           }
         }}
       >

--- a/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
+++ b/src/components/NewDraftWizard/WizardSteps/WizardCreateFolderStep.js
@@ -86,7 +86,7 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
     if (folder && folder?.folderId) {
       dispatch(updateNewDraftFolder(folder.folderId, Object.assign({ ...data, folder, selectedDraftsArray })))
         .then(() => {
-          navigate({ pathName: pathWithLocale("newdraft"), search: "step=1" })
+          navigate({ pathname: pathWithLocale(`newdraft/${folder.folderId}`), search: "step=1" })
           dispatch(resetTemplateAccessionIds())
         })
         .catch(error => {
@@ -95,8 +95,9 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
     } else {
       // Create a new folder with selected templates as drafts
       dispatch(createNewDraftFolder(data, selectedDraftsArray))
-        .then(() => {
-          navigate({ pathName: pathWithLocale("newdraft"), search: "step=1" })
+        .then(response => {
+          const folderId = response.data.folderId
+          navigate({ pathname: pathWithLocale(`newdraft/${folderId}`), search: "step=1" })
           dispatch(resetTemplateAccessionIds())
         })
         .catch(error => {
@@ -121,6 +122,7 @@ const CreateFolderForm = ({ createFolderFormRef }: { createFolderFormRef: Create
               error={!!error}
               helperText={error ? "Please give a name for folder." : null}
               disabled={isSubmitting}
+              inputProps={{ "data-testid": "folderName" }}
             />
           )}
           rules={{ required: true, validate: { name: value => value.length > 0 } }}

--- a/src/views/NewDraftWizard.js
+++ b/src/views/NewDraftWizard.js
@@ -1,16 +1,21 @@
 //@flow
-import React, { useRef } from "react"
+import React, { useRef, useEffect, useState } from "react"
 
 import Container from "@material-ui/core/Container"
+import LinearProgress from "@material-ui/core/LinearProgress"
 import Paper from "@material-ui/core/Paper"
 import { makeStyles } from "@material-ui/core/styles"
-import { useSelector } from "react-redux"
-import { useNavigate } from "react-router-dom"
+import { useDispatch } from "react-redux"
+import { useNavigate, useParams } from "react-router-dom"
 
 import WizardFooter from "components/NewDraftWizard/WizardComponents/WizardFooter"
 import WizardAddObjectStep from "components/NewDraftWizard/WizardSteps/WizardAddObjectStep"
 import WizardCreateFolderStep from "components/NewDraftWizard/WizardSteps/WizardCreateFolderStep"
 import WizardShowSummaryStep from "components/NewDraftWizard/WizardSteps/WizardShowSummaryStep"
+import { ResponseStatus } from "constants/responseStatus"
+import { updateStatus } from "features/statusMessageSlice"
+import { setFolder, resetFolder } from "features/wizardSubmissionFolderSlice"
+import folderAPIService from "services/folderAPI"
 import type { CreateFolderFormRef } from "types"
 import { useQuery, pathWithLocale } from "utils"
 import Page404 from "views/ErrorPages/Page404"
@@ -59,29 +64,58 @@ const getStepContent = (wizardStep: number, createFolderFormRef: CreateFolderFor
  * Some children components need to hook extra functionalities to "next step"-button, so reference hook it set here.
  */
 const NewDraftWizard = (): React$Element<typeof Container> => {
+  const dispatch = useDispatch()
   const classes = useStyles()
   const navigate = useNavigate()
+  const params = useParams()
   const queryParams = useQuery()
+  const [isFetchingFolder, setFetchingFolder] = useState(true)
 
   const step = queryParams.get("step")
+
+  const folderId = params.folderId
+
+  // Get folder if URL parameters have folderId. Redirect to home if invalid folderId
+  useEffect(() => {
+    let isMounted = true
+    const getFolder = async () => {
+      const response = await folderAPIService.getFolderById(folderId)
+      if (isMounted) {
+        if (response.ok) {
+          dispatch(setFolder(response.data))
+
+          setFetchingFolder(false)
+        } else {
+          navigate({ pathname: pathWithLocale("newdraft"), search: "step=0" })
+          dispatch(
+            updateStatus({
+              status: ResponseStatus.error,
+              response: response,
+              helperText: "Fetching folder error.",
+            })
+          )
+          dispatch(resetFolder())
+        }
+      }
+    }
+    if (folderId) getFolder()
+    return () => {
+      isMounted = false
+    }
+  }, [folderId])
 
   let wizardStep = step ? Number(step) : -1
 
   const createFolderFormRef = useRef<null | (HTMLFormElement & { changeCallback: Function })>(null)
 
-  // Fallback if no folder in state
-  const folder = useSelector(state => state.submissionFolder)
-
-  if (!folder && (wizardStep === 1 || wizardStep === 2)) {
-    wizardStep = 0
-    navigate({ pathName: pathWithLocale("newdraft"), search: "step=0" })
-  }
-
   return (
     <Container maxWidth={false} className={classes.container}>
-      <Paper className={wizardStep < 0 ? classes.paperFirstStep : classes.paper} elevation={wizardStep < 0 ? 2 : 0}>
-        <div className={classes.paperContent}>{getStepContent(wizardStep, createFolderFormRef)}</div>
-      </Paper>
+      {isFetchingFolder && folderId && <LinearProgress />}
+      {(!isFetchingFolder || !folderId) && (
+        <Paper className={wizardStep < 0 ? classes.paperFirstStep : classes.paper} elevation={wizardStep < 0 ? 2 : 0}>
+          <div className={classes.paperContent}>{getStepContent(wizardStep, createFolderFormRef)}</div>
+        </Paper>
+      )}
       <WizardFooter />
     </Container>
   )


### PR DESCRIPTION
### Description

Navigate draft wizard routes with folder id. This way wizard folder status doesn't reset if browser is refreshed.

### Related issues

Closes #530 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->

- Handle folder id as URL parameter for draft wizard routes.
- Navigate with folder id into wizard routes
- Get folder data if folder id is present and no folder is set into redux state
- Loading indicator for folder fetching
- Handle invalid form id
- Added integration tests with RTL

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests

