### PR TITLE
Update cypress tests for JSON schemas changes

### DIFF
--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -111,21 +111,21 @@ describe("Basic e2e", function () {
       // Analysis type
       cy.get("select[data-testid='analysisType']").select("Reference Alignment")
       cy.get("select[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
-      cy.get("[data-testid='analysisType.referenceAlignment.assembly.accessionId']").type("Standard Accession Id")
+      cy.get("[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard Accession version")
       cy.get("h4").contains("Sequence").parents().children("button").click()
-      cy.get("[data-testid='analysisType.referenceAlignment.sequence.0.accessionId']").type(
+      cy.get("[data-testid='analysisType.referenceAlignment.sequence.0.accession']").type(
         "Sequence Standard Accession Id"
       )
 
-      // Experiment
-      cy.get("h2").contains("Experiment Reference").parents().children("button").click()
-      cy.get("[data-testid='experimentRef.0.accessionId']").type("Experiment Test Accession Id")
-      cy.get("[data-testid='experimentRef.0.identifiers.submitterId.namespace']").type("Experiment Test Namespace")
-      cy.get("[data-testid='experimentRef.0.identifiers.submitterId.value']").type("Experiment Test Value")
-
       // Study
-      cy.get("[data-testid='studyRef.identifiers.submitterId.namespace']").type("Study Test Namespace")
-      cy.get("[data-testid='studyRef.identifiers.submitterId.value']").type("Study Test Value")
+      cy.get("[data-testid='studyRef.accessionId']").type("Study Test Accession Id")
+      cy.get("[data-testid='studyRef.refname']").type("Study Test Record Name")
+      cy.get("[data-testid='studyRef.refcenter']").type("Study Test Namespace")
+
+      // Experiment
+      cy.get("[data-testid='experimentRef.accessionId']").type("Experiment Test Accession Id")
+      cy.get("[data-testid='experimentRef.refcenter']").type("Experiment Test Record Name")
+      cy.get("[data-testid='experimentRef.refname']").type("Experiment Test Namespace")
 
       // Sample
       cy.get("h2").contains("Sample Reference").parents().children("button").click()

--- a/cypress/integration/doiForm.spec.ts
+++ b/cypress/integration/doiForm.spec.ts
@@ -15,12 +15,12 @@ describe("DOI form", function () {
 
     const testRunData = {
       title: "Test Run",
-      experimentRefLabel: "Test Experiment reference label",
+      experimentAccessionId: "Test Experiment AccessionId",
     }
 
     cy.get("[data-testid='title']").type(testRunData.title)
     cy.get("[data-testid='experimentRef']").parents().children("button").click()
-    cy.get("[data-testid='experimentRef.0.label']").type(testRunData.experimentRefLabel)
+    cy.get("[data-testid='experimentRef.0.accessionId']").type(testRunData.experimentAccessionId)
 
     const testRunFile = {
       fileName: "Run file name",
@@ -54,7 +54,7 @@ describe("DOI form", function () {
     cy.get("[data-testid='title']").type(testAnalysisData.title1)
     cy.get("[data-testid='analysisType']").select("Reference Alignment")
     cy.get("[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
-    cy.get("[data-testid='analysisType.referenceAlignment.assembly.accessionId']").type("Standard Accession Id")
+    cy.get("[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard Accession Version")
 
     const testAnalysisFile = {
       fileName: "Analysis file name",
@@ -81,7 +81,7 @@ describe("DOI form", function () {
     cy.get("[data-testid='title']").type(testAnalysisData.title2)
     cy.get("[data-testid='analysisType']").select("Reference Alignment")
     cy.get("[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
-    cy.get("[data-testid='analysisType.referenceAlignment.assembly.accessionId']").type("Standard Accession Id")
+    cy.get("[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard Accession Id")
     // Select fileType
     cy.get("[data-testid='files.0.filename']").type(testAnalysisFile.fileName)
     cy.get("[data-testid='files.0.filetype']").select(testAnalysisFile.fileType2)

--- a/cypress/integration/editForm.spec.ts
+++ b/cypress/integration/editForm.spec.ts
@@ -72,7 +72,7 @@ describe("Populate form and render form elements by object data", function () {
       description: "Test experiment description",
       designDescription: "Test design description",
       sampleReference: "Individual Sample",
-      individualSampleLabel: "Individual Sample test label",
+      individualSampleAccessionId: "Individual Sample AccessionId",
       singleProcessing: "Single Processing",
       singleProcessingLabel: "Single Processing label",
       complexProcessing: "Complex Processing",
@@ -87,28 +87,15 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[data-testid='title']").type(testData.title)
     cy.get("[data-testid='description']").type(testData.description)
     cy.get("[data-testid='design.designDescription']").type(testData.designDescription)
-    cy.get("select[data-testid='design.sampleDescriptor']").select(testData.sampleReference)
-    cy.get("[data-testid='design.sampleDescriptor.label']").type(testData.individualSampleLabel)
+    cy.get("select[data-testid='design.sampleDescriptor']", { timeout: 10000 }).select(testData.sampleReference)
+    cy.get("[data-testid='design.sampleDescriptor.accessionId']").type(testData.individualSampleAccessionId)
+
     // Expected Base Call Table
     cy.get("div").contains("Expected Base Call Table").parents().children("button").click()
     cy.get("[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable.0.baseCall']").type("Test base call")
     cy.get("[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable.0.readGroupTag']").type(
       "Test read group tag"
     )
-
-    // Select and fill Single processing
-    cy.get("select[data-testid='processing']").select(testData.singleProcessing)
-    cy.get("input[data-testid='processing']").type(testData.singleProcessingLabel)
-
-    // Switch to select and fill Complex processing
-    cy.get("select[data-testid='processing']").select(testData.complexProcessing)
-    cy.get("[data-testid='processing']").parents().children("button").click()
-    cy.get("[data-testid='processing.0.pipeline.pipeSection']").parent().children("button").click()
-    cy.get("[data-testid='processing.0.pipeline.pipeSection.0.stepIndex']").type(testData.stepIndex)
-    cy.get("select[data-testid='processing.0.pipeline.pipeSection.0.prevStepIndex']").select(testData.stringValue, {
-      force: true,
-    })
-    cy.get("input[data-testid='processing.0.pipeline.pipeSection.0.prevStepIndex']").type(testData.prevStepIndexValue)
 
     // Save Experiment form
     cy.get("button[type='button']").contains("Save as Draft").click()
@@ -120,8 +107,11 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[data-testid='title']").should("have.value", testData.title)
     cy.get("[data-testid='description']").should("have.value", testData.description)
     cy.get("[data-testid='design.designDescription']").should("have.value", testData.designDescription)
-    cy.get("[data-testid='design.sampleDescriptor']").should("have.value", testData.sampleReference)
-    cy.get("[data-testid='design.sampleDescriptor.label']").should("have.value", testData.individualSampleLabel)
+    cy.get("select[data-testid='design.sampleDescriptor']").should("have.value", testData.sampleReference)
+    cy.get("[data-testid='design.sampleDescriptor.accessionId']").should(
+      "have.value",
+      testData.individualSampleAccessionId
+    )
     cy.get("[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable.0.baseCall']").should(
       "have.value",
       "Test base call"
@@ -130,25 +120,12 @@ describe("Populate form and render form elements by object data", function () {
       "have.value",
       "Test read group tag"
     )
-    cy.get("[data-testid='processing.0.pipeline.pipeSection.0.stepIndex']").should("have.value", testData.stepIndex)
-    cy.get("input[data-testid='processing.0.pipeline.pipeSection.0.prevStepIndex']").should(
-      "have.value",
-      testData.prevStepIndexValue
-    )
-
-    // Change Prev Step Index from string value to null
-    cy.get("select[data-testid='processing.0.pipeline.pipeSection.0.prevStepIndex']").select(testData.nullValue, {
-      force: true,
-    })
 
     // Save Experiment form 2nd time
     cy.get("button[type='button']").contains("Update draft").click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft updated with")
 
     cy.continueFirstDraft()
-
-    // Test that Prev Step Index is nulled
-    cy.get("input[data-testid='processing.0.pipeline.pipeSection.0.prevStepIndex']").should("not.exist")
   })
 
   it("should render Run form correctly when editing", () => {
@@ -162,7 +139,7 @@ describe("Populate form and render form elements by object data", function () {
 
     cy.get("[data-testid='title']").type(testData.title)
     cy.get("select[data-testid='runType.referenceAlignment.assembly']").select(testData.referenceAlignment)
-    cy.get("[data-testid='runType.referenceAlignment.assembly.accessionId']").type(testData.accessionId)
+    cy.get("[data-testid='runType.referenceAlignment.assembly.accession']").type(testData.accessionId)
 
     // Save draft
     cy.get("button[type='button']").contains("Save as Draft").click()
@@ -172,7 +149,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.continueFirstDraft()
 
     cy.get("[data-testid='runType.referenceAlignment.assembly']").should("have.value", testData.referenceAlignment)
-    cy.get("[data-testid='runType.referenceAlignment.assembly.accessionId']").should("have.value", testData.accessionId)
+    cy.get("[data-testid='runType.referenceAlignment.assembly.accession']").should("have.value", testData.accessionId)
   })
 
   it("should render form with checkboxes correctly", () => {

--- a/cypress/integration/linkingAccessionIds.spec.ts
+++ b/cypress/integration/linkingAccessionIds.spec.ts
@@ -35,16 +35,7 @@ describe("Linking Accession Ids", function () {
       .as("studyAccessionId")
 
     // Fill a Sample form
-    cy.get("div[role=button]").contains("Sample").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("Sample")
     cy.get("[data-testid='title']").type("Test Sample title")
     cy.get("[data-testid='sampleName.taxonId']").type("123")
     // Submit Sample form
@@ -57,44 +48,43 @@ describe("Linking Accession Ids", function () {
       .as("sampleAccessionId")
 
     // Experiment form
-    cy.get("div[role=button]").contains("Experiment").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("Experiment")
     cy.get("[data-testid='title']").type("Test Experiment title")
-    cy.get("[data-testid='studyRef.label']").type("Study Label")
+
+    cy.get("select[data-testid='platform']").select("AB 5500 Genetic Analyzer")
+    cy.get("select[data-testid='platform']").should("have.value", "AB 5500 Genetic Analyzer")
 
     // Select studyAccessionId
-    cy.get("select[data-testid='studyRef.accessionId']").then(($el: any) => {
-      const studyAccessionId = cy.get("@studyAccessionId")
-      $el.click()
-      $el.select(studyAccessionId)
-    })
+    cy.get("@studyAccessionId").then(id =>
+      cy.get("select[data-testid='studyRef.accessionId']").select(`${id} - File name: testFile.xml`)
+    )
+
     cy.get("select[data-testid='studyRef.accessionId']").should("contain", " - File name:")
 
     cy.get("textarea[data-testid='design.designDescription']").type("Design description")
     cy.get("select[data-testid='design.sampleDescriptor']").select("Individual Sample")
-    cy.get("input[data-testid='design.sampleDescriptor.label']").type("Sample label")
+    cy.get("select[data-testid='design.sampleDescriptor']").should("have.value", "Individual Sample")
+
     // Select sampleAccessionId
-    cy.get("select[data-testid='design.sampleDescriptor.accessionId']").then(($el: any) => {
-      const sampleAccessionId = cy.get("@sampleAccessionId")
-      $el.select(sampleAccessionId)
-    })
+    cy.get("@sampleAccessionId").then(id =>
+      cy.get("select[data-testid='design.sampleDescriptor.accessionId']").select(`${id} - Title: Test Sample title`)
+    )
+
     cy.get("select[data-testid='design.sampleDescriptor.accessionId']").should("contain", " - Title:")
 
     cy.get("select[data-testid='design.libraryDescriptor.libraryStrategy']").select("AMPLICON")
+    cy.get("select[data-testid='design.libraryDescriptor.libraryStrategy']").should("have.value", "AMPLICON")
     cy.get("select[data-testid='design.libraryDescriptor.librarySource']").select("GENOMIC")
+    cy.get("select[data-testid='design.libraryDescriptor.librarySource']").should("have.value", "GENOMIC")
     cy.get("select[data-testid='design.libraryDescriptor.librarySelection']").select("CAGE")
-    cy.get("select[data-testid='platform']").select("AB 5500 Genetic Analyzer")
+    cy.get("select[data-testid='design.libraryDescriptor.librarySelection']", { timeout: 10000 }).should(
+      "have.value",
+      "CAGE"
+    )
+
     // Submit Experiment form
     cy.formActions("Submit")
-    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+    cy.get("[data-testid='Form-objects']", { timeout: 10000 }).should("have.length", 1)
 
     // Get experimentAccessionId
     cy.get(".MuiListItem-container > div > div > p")
@@ -102,24 +92,15 @@ describe("Linking Accession Ids", function () {
       .as("experimentAccessionId")
 
     // Run form
-    cy.get("div[role=button]").contains("Run").click()
-    cy.get("div[aria-expanded='true']", { timeout: 10000 })
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("Run")
     cy.get("[data-testid='title']").type("Test Run title")
     cy.get("h2[data-testid='experimentRef']").parents().children("button").click()
-    cy.get("[data-testid='experimentRef.0.label']").type("Test experiment label ref")
+
     // Select experimentAccessionId
-    cy.get("select[data-testid='experimentRef.0.accessionId']").then(($el: any) => {
-      const experimentAccessionId = cy.get("@experimentAccessionId")
-      $el.select(experimentAccessionId)
-    })
+    cy.get("@experimentAccessionId").then(id =>
+      cy.get("select[data-testid='experimentRef.0.accessionId']").select(`${id} - Title: Test Experiment title`)
+    )
+
     cy.get("select[data-testid='experimentRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Run form
@@ -132,49 +113,40 @@ describe("Linking Accession Ids", function () {
       .as("runAccessionId")
 
     // Analysis form
-    cy.get("div[role=button]").contains("Analysis").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("Analysis")
     cy.get("[data-testid='title']").type("Test Analysis title")
     cy.get("select[data-testid='analysisType']").select("Reference Alignment")
     cy.get("select[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
-    cy.get("input[data-testid='analysisType.referenceAlignment.assembly.accessionId']").type("Standard accessionId")
+    cy.get("input[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard accessionId")
+
     // Select studyAccessionId
-    cy.get("select[data-testid='studyRef.accessionId']").then(($el: any) => {
-      const studyAccessionId = cy.get("@studyAccessionId")
-      $el.select(studyAccessionId)
-    })
+    cy.get("@studyAccessionId").then(id =>
+      cy.get("select[data-testid='studyRef.accessionId']").select(`${id} - File name: testFile.xml`)
+    )
+
     cy.get("select[data-testid='studyRef.accessionId']").should("contain", " - File name:")
 
     // Select experimentAccessionId
-    cy.get("div").contains("Experiment Reference").parents().children("button").click()
-    cy.get("select[data-testid='experimentRef.0.accessionId']").then(($el: any) => {
-      const experimentAccessionId = cy.get("@experimentAccessionId")
-      $el.select(experimentAccessionId)
-    })
-    cy.get("select[data-testid='experimentRef.0.accessionId']").should("contain", " - Title:")
+    cy.get("@experimentAccessionId").then(id =>
+      cy.get("select[data-testid='experimentRef.accessionId']").select(`${id} - Title: Test Experiment title`)
+    )
+
+    cy.get("select[data-testid='experimentRef.accessionId']").should("contain", " - Title:")
 
     // Select sampleAccessionId
     cy.get("div").contains("Sample Reference").parents().children("button").click()
-    cy.get("select[data-testid='sampleRef.0.accessionId']").then(($el: any) => {
-      const sampleAccessionId = cy.get("@sampleAccessionId")
-      $el.select(sampleAccessionId)
-    })
+    cy.get("@sampleAccessionId").then(id =>
+      cy.get("select[data-testid='sampleRef.0.accessionId']").select(`${id} - Title: Test Sample title`)
+    )
+
     cy.get("select[data-testid='sampleRef.0.accessionId']").should("contain", " - Title:")
 
     // Select runAccessionId
     cy.get("div").contains("Run Reference").parents().children("button").click()
-    cy.get("select[data-testid='runRef.0.accessionId']").then(($el: any) => {
-      const runAccessionId = cy.get("@runAccessionId")
-      $el.select(runAccessionId)
-    })
+    cy.get("@runAccessionId").then(id =>
+      cy.get("select[data-testid='runRef.0.accessionId']").select(`${id} - Title: Test Run title`)
+    )
+
     cy.get("select[data-testid='runRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Analysis form
@@ -191,14 +163,15 @@ describe("Linking Accession Ids", function () {
     cy.get("[data-testid='title']").type("Test Analysis title 2")
     cy.get("select[data-testid='analysisType']").select("Reference Alignment")
     cy.get("select[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
-    cy.get("input[data-testid='analysisType.referenceAlignment.assembly.accessionId']").type("Standard accessionId 2")
+    cy.get("input[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard accessionId 2")
 
     // Select the other Analysis AccessionId
     cy.get("div").contains("Analysis Reference").parents().children("button").click()
-    cy.get("select[data-testid='analysisRef.0.accessionId']").then(($el: any) => {
-      const analysisAccessionId = cy.get("@analysisAccessionId")
-      $el.select(analysisAccessionId)
-    })
+
+    cy.get("@analysisAccessionId").then(id =>
+      cy.get("select[data-testid='analysisRef.0.accessionId']").select(`${id} - Title: Test Analysis title`)
+    )
+
     cy.get("select[data-testid='analysisRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Analysis form
@@ -206,16 +179,7 @@ describe("Linking Accession Ids", function () {
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
 
     // Fill DAC form
-    cy.get("div[role=button]").contains("DAC").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("DAC")
 
     cy.get("h2[data-testid='contacts']").parents().children("button").click()
     cy.get("[data-testid='contacts.0.name']").type("Test contact name")
@@ -235,22 +199,12 @@ describe("Linking Accession Ids", function () {
       .as("dacAccessionId")
 
     // Fill Policy form
-    cy.get("div[role=button]").contains("Policy").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
+    cy.clickFillForm("Policy")
     cy.get("[data-testid='title']").type("Test Policy title")
-    cy.get("input[data-testid='dacRef.label']").type("Test DAC")
-    cy.get("select[data-testid='dacRef.accessionId']").then(($el: any) => {
-      const dacAccessionId = cy.get("@dacAccessionId")
-      $el.select(dacAccessionId)
-    })
+    cy.get("@dacAccessionId").then(id =>
+      cy.get("select[data-testid='dacRef.accessionId']").select(`${id} - Main Contact: Test contact name`)
+    )
+
     cy.get("select[data-testid='dacRef.accessionId']").should("contain", " - Main Contact:")
 
     cy.get("select[data-testid='policy']").select("Policy Text")
@@ -264,42 +218,32 @@ describe("Linking Accession Ids", function () {
       .as("policyAccessionId")
 
     // Fill Dataset form
-    cy.get("div[role=button]").contains("Dataset").click()
-    cy.get("div[aria-expanded='true']")
-      .siblings()
-      .within(() =>
-        cy
-          .get("div[role=button]")
-          .contains("Fill Form", { timeout: 10000 })
-          .should("be.visible")
-          .then($btn => $btn.click())
-      )
-
+    cy.clickFillForm("Dataset")
     cy.get("[data-testid='title']").type("Test Dataset title")
     cy.get("[data-testid='description']").type("Dataset description")
     cy.get("[data-testid='datasetType']").first().check()
 
     // Select policyAccessionId
-    cy.get("select[data-testid='policyRef.accessionId']").then(($el: any) => {
-      const policyAccessionId = cy.get("@policyAccessionId")
-      $el.select(policyAccessionId)
-    })
+    cy.get("@policyAccessionId").then(id =>
+      cy.get("select[data-testid='policyRef.accessionId']").select(`${id} - Title: Test Policy title`)
+    )
+
     cy.get("select[data-testid='policyRef.accessionId']").should("contain", " - Title:")
 
     // Select runAccessionId
     cy.get("div").contains("Run Reference").parents().children("button").click()
-    cy.get("select[data-testid='runRef.0.accessionId']").then(($el: any) => {
-      const runAccessionId = cy.get("@runAccessionId")
-      $el.select(runAccessionId)
-    })
+    cy.get("@runAccessionId").then(id =>
+      cy.get("select[data-testid='runRef.0.accessionId']").select(`${id} - Title: Test Run title`)
+    )
+
     cy.get("select[data-testid='runRef.0.accessionId']").should("contain", " - Title:")
 
     // Select analysisAccessionId
     cy.get("div").contains("Analysis Reference").parents().children("button").click()
-    cy.get("select[data-testid='analysisRef.0.accessionId']").then(($el: any) => {
-      const analysisAccessionId = cy.get("@analysisAccessionId")
-      $el.select(analysisAccessionId)
-    })
+    cy.get("@analysisAccessionId").then(id =>
+      cy.get("select[data-testid='analysisRef.0.accessionId']").select(`${id} - Title: Test Analysis title`)
+    )
+
     cy.get("select[data-testid='analysisRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Dataset form

--- a/cypress/integration/pagination.spec.ts
+++ b/cypress/integration/pagination.spec.ts
@@ -1,4 +1,5 @@
 describe("unpublished folders, published folders, and user's draft templates pagination", function () {
+  beforeEach(() => cy.task("resetDb"))
   it("should renders pagination for unpublished folders list correctly", () => {
     // Mock responses for Unpublished Folders
     const unpublishedFoldersResponse10 = {

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -711,7 +711,7 @@ const FormTextField = ({
   return (
     <ConnectForm>
       {({ control }: { control: any }) => {
-        const multiLineRowIdentifiers = ["description", "abstract", "policy text"]
+        const multiLineRowIdentifiers = ["abstract", "description", "policy text"]
 
         return (
           <Controller
@@ -1416,7 +1416,7 @@ const FormArray = ({ object, path, required, description }: FormArrayProps & { d
     if (index === 0) setValid(false)
     // Set the correct values according to the name path when removing a field
     const values = getValues(name)
-    const filteredValues = values.filter((val: any, ind: any) => ind !== index)
+    const filteredValues = values?.filter((val: any, ind: any) => ind !== index)
     setValue(name, filteredValues)
     remove(index)
   }

--- a/src/components/NewDraftWizard/WizardHooks/WizardLinkedDereferencedSchemaHook.tsx
+++ b/src/components/NewDraftWizard/WizardHooks/WizardLinkedDereferencedSchemaHook.tsx
@@ -78,9 +78,7 @@ const getLinkedDereferencedSchema = (
         dereferencedSchema = merge({}, dereferencedSchema, {
           properties: {
             experimentRef: {
-              items: {
-                properties: { accessionId: { enum: experimentAccessionIds } },
-              },
+              properties: { accessionId: { enum: experimentAccessionIds } },
             },
           },
         })


### PR DESCRIPTION
### Description

Update cypress tests according to new changes in JSON schemas from backend.

### Related issues

Closes https://github.com/CSCfi/metadata-submitter-frontend/issues/622

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Changed `accessionId` field to `accession`
- Removed unnecessary/no longer exist fields in `Run` and `Experiment` forms
- Restructured linking accessionIds between different forms.


### Testing

- [x] Integration Tests

