### PR TITLE
Bugfix/invalid field format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Disallow use of "any" type #624
 - Date picker #559
 - New login page #573
 - Autocomplete name field in DOI form #529
@@ -65,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cast integer fields as numbers #661
 - Handle required form array fields #484
 - Prevent user deleting object in published folder #486
 - Display error when replacing XML file with file with same name #483

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -131,6 +131,9 @@ const cleanUpFormValues = (data: unknown) => {
   return traverseFormValuesForCleanUp(cleanedData)
 }
 
+// Array is populated in traverseFields method.
+const integerFields: Array<string> = []
+
 const traverseFormValuesForCleanUp = (data: Record<string, unknown>) => {
   Object.keys(data).forEach(key => {
     const property = data[key] as Record<string, unknown> | string | null
@@ -143,7 +146,11 @@ const traverseFormValuesForCleanUp = (data: Record<string, unknown>) => {
     }
     if (property === "") {
       delete data[key]
-    } else if (typeof property === "string" && !isNaN(Number(data[key])) && key !== "telephoneNumber") {
+    }
+    // Integer typed fields are considered as string like ID's which are numbers.
+    // Therefore these fields need to be handled as string in the form and cast as number
+    // for backend operations. Eg. "1234" is converted to 1234 so it passes backend validation
+    else if (integerFields.indexOf(key) > -1) {
       data[key] = Number(data[key])
     }
   })
@@ -275,6 +282,10 @@ const traverseFields = (
       )
     }
     case "integer": {
+      // List fields with integer type in schema. List is used as helper when cleaning up fields for backend.
+      const fieldName = name.split(".").pop()
+      if (fieldName && integerFields.indexOf(fieldName) < 0) integerFields.push(fieldName)
+
       return <FormTextField key={name} name={name} label={label} required={required} description={description} />
     }
     case "number": {


### PR DESCRIPTION
### Description

All string typed numbers (except `telephoneNumber` field) were cast as numbers when passing data to request payload. This resulted in behavior where in some occasions those value types were incorrect and raised validation issues in the backend.

### Related issues

Fixes #660 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

- Removed console log
- Gather integer typed fields from schema to an array
- Cast matching field value to number

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

Active tests should be sufficient since we have test cases for both Sample / TaxonId (integer type) and DAC / Contact form / Telephone number (string type with integer value).