### PR TITLE
Update text field value with setValue method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update text field value with `setValue` method #666
 - Cast integer fields as numbers #661
 - Disallow object update with invalid form #656
 - Handle required form array fields #484

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -190,8 +190,15 @@ describe("Basic e2e", function () {
 
     // Submit form
     cy.formActions("Submit")
-    // Saved objects list should have newly added item from Analysis object
+    // Saved objects list should have newly added item from DAC object
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Test DAC form update
+    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("[data-testid='contacts.0.name']").type(" edited")
+    cy.get("button[type=submit]").contains("Update").click()
+    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("[data-testid='contacts.0.name']").should("have.value", "Test contact name edited")
 
     // Navigate to summary
     cy.get("button[type=button]").contains("Next").click()

--- a/src/components/Home/UserDraftTemplates.tsx
+++ b/src/components/Home/UserDraftTemplates.tsx
@@ -75,7 +75,6 @@ const UserDraftTemplates: React.FC = () => {
 
   // Render when there is user's draft template(s)
   const DraftList = () => {
-    console.log(templates)
     return (
       <React.Fragment>
         {templates.map((draft: { [key: string]: ObjectInsideFolderWithTags[] }, index: number) => (

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -727,7 +727,9 @@ const FormTextField = ({
 
               const handleChange = (e: { target: { value: string | number } }) => {
                 const { value } = e.target
-                field.onChange(type === "string" && typeof value === "number" ? value.toString() : value)
+                const parsedValue = type === "string" && typeof value === "number" ? value.toString() : value
+                field.onChange(parsedValue) // Helps with Cypress change detection
+                setValue(name, parsedValue) // Enables update of nested fields, eg. DAC contact
               }
 
               return (


### PR DESCRIPTION
### Description

Current text field updates don't work with some nested fields (at least with DAC contact). Updating field value with `setValue` method seems to fix the problem.

My own theory is that there might be some render timing problems with `field.onChange` method when using controlled input and it would re-render the fields with original values and therefore updated value won't make it to change detection.

For some reason I'm unable to trigger validation in DAC form in Cypress test when using only `setValue` method to update the value. Using both `field.onChange` & `setValue` methods seems to work in both development and Cypress environments,


### Related issues

Fixes #657 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->

- Removed console log
- Update text field value with `setValue` and `field.onChange` methods
- Updated E2E tests to include test for DAC form edit
- Updated changelog

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests

