### PR TITLE
Enable removal of field array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update text field value with `setValue` method #666
 - Cast integer fields as numbers #661
+- Remove form array items in saved / submitted objects #659
 - Disallow object update with invalid form #656
 - Handle required form array fields #484
 - Prevent user deleting object in published folder #486

--- a/cypress/integration/objectLinksAttributes.spec.ts
+++ b/cypress/integration/objectLinksAttributes.spec.ts
@@ -97,6 +97,11 @@ describe("render objects' links and attributes ", function () {
 
     cy.get("select[data-testid='studyLinks.0']").should("have.value", "XRef Link")
     cy.get("select[data-testid='studyLinks.1']").should("have.value", "Entrez Link")
+
+    // Test that removed link item is removed also from backend
+    cy.formActions("Update")
+    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("div[data-testid='studyLinks'] > div", { timeout: 30000 }).should("have.length", 2)
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3034,37 +3034,6 @@
         "strict-event-emitter": "^0.2.0"
       }
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-alpha.68",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.68.tgz",
-      "integrity": "sha512-q+3gX6EHuM/AyOn8fkoANQxSzIHBeuNsrGgb7SPP0y7NuM+4ZHG/b9882+OfHcilaSqPDWUQoLbphcBpw/m/RA==",
-      "dependencies": {
-        "@babel/runtime": "^7.17.0",
-        "@emotion/is-prop-valid": "^1.1.1",
-        "@mui/utils": "^5.4.1",
-        "@popperjs/core": "^2.4.4",
-        "clsx": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/codemod": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@mui/codemod/-/codemod-5.3.0.tgz",
@@ -29685,20 +29654,6 @@
         "strict-event-emitter": "^0.2.0"
       }
     },
-    "@mui/base": {
-      "version": "5.0.0-alpha.68",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.68.tgz",
-      "integrity": "sha512-q+3gX6EHuM/AyOn8fkoANQxSzIHBeuNsrGgb7SPP0y7NuM+4ZHG/b9882+OfHcilaSqPDWUQoLbphcBpw/m/RA==",
-      "requires": {
-        "@babel/runtime": "^7.17.0",
-        "@emotion/is-prop-valid": "^1.1.1",
-        "@mui/utils": "^5.4.1",
-        "@popperjs/core": "^2.4.4",
-        "clsx": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      }
-    },
     "@mui/codemod": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@mui/codemod/-/codemod-5.3.0.tgz",
@@ -29957,8 +29912,7 @@
       },
       "dependencies": {
         "@mui/base": {
-          "version": "5.0.0-alpha.67",
-          "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.67.tgz",
+          "version": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.67.tgz",
           "integrity": "sha512-yK2++NivZUitAVpheMc5QVuwrVCphrTw85L6qjKcvnSpB8wmVYne58CY2vzMCNEuHkuHG2jccq9/JlRZFGAanw==",
           "requires": {
             "@babel/runtime": "^7.16.7",


### PR DESCRIPTION
### Description

User was not able to remove form array item from saved / submitted form. Solution is to render form arrays as editable state objects. 

JSON schema parser does cleaning for form values by deleting object keys with empty values. This however removes also keys with value of empty array. This is fixed by allowing empty arrays as form values.

### Related issues

Fixes #659

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Render form arrays with useState hook
- Disable deletion of empty arrays from form values when cleaning data
- Updated E2E test and changelog

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Integration Tests
