### PR TITLE
Feature/DOI-keywords-and-integration-tests

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,7 +22,7 @@ jobs:
           if [[ $BRANCH == master ]]; then
              echo "VERSION=master" >> $GITHUB_ENV
           else
-             echo "VERSION=feature/metax-integration" >> $GITHUB_ENV
+             echo "VERSION=develop" >> $GITHUB_ENV
           fi
       - name: Clone backend
         uses: actions/checkout@v3

--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,7 +22,7 @@ jobs:
           if [[ $BRANCH == master ]]; then
              echo "VERSION=master" >> $GITHUB_ENV
           else
-             echo "VERSION=develop" >> $GITHUB_ENV
+             echo "VERSION=feature/metax-integration" >> $GITHUB_ENV
           fi
       - name: Clone backend
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Field Keywords in DOI form #715
 - Option to filter by submission's name in Home page #685
 - New navigation bar and new home page #669
 

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -1,5 +1,3 @@
-import { FormInput } from "../support/types"
-
 describe("Basic e2e", function () {
   beforeEach(() => {
     cy.task("resetDb")
@@ -9,7 +7,7 @@ describe("Basic e2e", function () {
     cy.login()
   })
 
-  it("should create new folder, add Study form, upload Study XML file, add Analysis form, add DAC form, and publish folder", () => {
+  it("should create new folder, add Study form, add Analysis form, add DAC form, and publish folder", () => {
     cy.login()
 
     cy.get("button", { timeout: 10000 }).contains("Create submission").click()
@@ -19,31 +17,6 @@ describe("Basic e2e", function () {
 
     // Skip-link
     cy.clickFillForm("Study")
-
-    cy.get("div[role=button]").contains("Fill Form").should("be.visible").type("{enter}")
-
-    cy.get("div[role=button]").contains("Skip to form").should("be.visible")
-
-    // Try to send invalid form
-    cy.formActions("Submit")
-
-    cy.get<FormInput[]>("input[data-testid='descriptor.studyTitle']").then($input => {
-      expect($input[0].validationMessage).to.contain("Please fill")
-    })
-
-    // Fill a Study form and submit object
-    cy.get("[data-testid='descriptor.studyTitle']").type("Test title")
-    cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Test title")
-
-    cy.formActions("Clear form")
-
-    cy.get("[data-testid='descriptor.studyTitle']").type("New title")
-    cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "New title")
-    cy.get("[data-testid='descriptor.studyType']").select("Metagenomics")
-
-    // Submit form
-    cy.formActions("Submit")
-    cy.get("[data-testid='Form-objects']").find("li").should("have.length", 1)
 
     // Upload a Study xml file.
     cy.get("div[role=button]")
@@ -64,28 +37,7 @@ describe("Basic e2e", function () {
     cy.get("form").submit()
 
     // Saved objects list should have newly added item from Study object
-    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
-
-    // Replace the same XML to see error message
-    cy.get("button[type=button]")
-      .contains("Replace")
-      .should("be.visible")
-      .then($el => $el.click())
-    cy.get(".MuiCardHeader-action").contains("Replace")
-    cy.fixture("study_test.xml").then(fileContent => {
-      cy.get("[data-testid='xml-upload']").attachFile(
-        {
-          fileContent: fileContent.toString(),
-          fileName: "testFile.xml",
-          mimeType: "text/xml",
-        },
-        { force: true }
-      )
-    })
-    cy.get("form").submit()
-    cy.contains(".MuiAlert-message", " Some items (e.g: accessionId, publishDate, dateCreated) cannot be changed.", {
-      timeout: 10000,
-    })
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
     // Replace the modified XML file
     cy.get("button[type=button]")
@@ -104,7 +56,7 @@ describe("Basic e2e", function () {
       )
     })
     cy.get("form").submit()
-    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 2)
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
     cy.contains(".MuiAlert-message", "Object replaced")
 
     // Fill an Analysis form and submit object
@@ -212,7 +164,7 @@ describe("Basic e2e", function () {
     cy.get("button[type=button]").contains("Next").click()
 
     // Check the amount of submitted objects in each object type
-    cy.get("h6").contains("Study").parents("div").children().eq(1).should("have.text", 2)
+    cy.get("h6").contains("Study").parents("div").children().eq(1).should("have.text", 1)
     cy.get("h6").contains("Analysis").parents("div").children().eq(1).should("have.text", 1)
 
     // Navigate to publish

--- a/cypress/integration/doiForm.spec.ts
+++ b/cypress/integration/doiForm.spec.ts
@@ -198,6 +198,22 @@ describe("DOI form", function () {
       cy.get("[data-testid='subjects']").parent().children("button").click()
       cy.get("select[data-testid='subjects.0.subject']").select("FOS: Mathematics")
 
+      // Fill in required Keywords
+      cy.get("[data-testid='keywords']").parent().children("button").click()
+      cy.get("input[data-testid='keywords.0']").type("keyword-1,")
+      cy.get("input[data-testid='keywords.0']").type("keyword-2{enter}")
+      cy.get("input[data-testid='keywords.0']").type("keyword-3{enter}")
+      // Try typing the same keyword and check that we don't show repeated keyword
+      cy.get("input[data-testid='keywords.0']").type("keyword-2{enter}")
+
+      cy.get("div[data-testid='keyword-1']").should("be.visible")
+      cy.get("div[data-testid='keyword-2']").should("be.visible")
+      cy.get("div[data-testid='keyword-3']").should("be.visible")
+
+      // Try deleting a tag and check that it shouldn't exist anymore
+      cy.get("div[data-testid='keyword-2'] > [data-testid='ClearIcon']").click()
+      cy.get("div[data-testid='keyword-2']").should("not.exist")
+
       cy.get("button[type='submit']").click()
       cy.contains(".MuiAlert-message", "DOI form has been saved successfully")
 
@@ -205,6 +221,8 @@ describe("DOI form", function () {
       cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
       cy.get("[data-testid='creators.0.givenName']").should("have.value", "John Smith")
       cy.get("select[data-testid='subjects.0.subject']").should("have.value", "FOS: Mathematics")
+      cy.get("div[data-testid='keyword-1']").scrollIntoView().should("be.visible")
+      cy.get("div[data-testid='keyword-3']").scrollIntoView().should("be.visible")
     }),
     it("should autofill full name based on family and given name", () => {
       // Go to DOI form
@@ -237,6 +255,10 @@ describe("DOI form", function () {
     // Fill in required Subjects field
     cy.get("[data-testid='subjects']").parent().children("button").click()
     cy.get("[data-testid='subjects.0.subject']").select("FOS: Mathematics")
+
+    // Fill in required Keywords
+    cy.get("[data-testid='keywords']").parent().children("button").click()
+    cy.get("input[data-testid='keywords.0']").type("keyword-1,")
 
     // Select Dates
     cy.get("[data-testid='dates']").parent().children("button").click()

--- a/cypress/integration/doiForm.spec.ts
+++ b/cypress/integration/doiForm.spec.ts
@@ -192,21 +192,20 @@ describe("DOI form", function () {
 
       // Fill in required Creators field
       cy.get("[data-testid='creators']").parent().children("button").click()
-      cy.get("[data-testid='creators.0.givenName']").type("John Smith")
-
+      cy.get("[data-testid='creators.0.givenName']").type("Test given name")
+      cy.get("[data-testid='creators.0.familyName']").type("Test family name")
       // Fill in required Subjects field
       cy.get("[data-testid='subjects']").parent().children("button").click()
       cy.get("select[data-testid='subjects.0.subject']").select("FOS: Mathematics")
 
       // Fill in required Keywords
-      cy.get("[data-testid='keywords']").parent().children("button").click()
-      cy.get("input[data-testid='keywords.0']").type("keyword-1,")
-      cy.get("input[data-testid='keywords.0']").type("keyword-2{enter}")
-      cy.get("input[data-testid='keywords.0']").type("keyword-3{enter}")
+      cy.get("input[data-testid='keywords']").type("keyword-1,")
+      cy.get("input[data-testid='keywords']").type("keyword-2{enter}")
+      cy.get("input[data-testid='keywords']").type("keyword-3{enter}")
       // Try typing the same keyword and check that we don't show repeated keyword
-      cy.get("input[data-testid='keywords.0']").type("keyword-2{enter}")
+      cy.get("input[data-testid='keywords']").type("keyword-2{enter}")
 
-      cy.get("div[data-testid='keyword-1']").should("be.visible")
+      cy.get("div[data-testid='keyword-1']").scrollIntoView().should("be.visible")
       cy.get("div[data-testid='keyword-2']").should("be.visible")
       cy.get("div[data-testid='keyword-3']").should("be.visible")
 
@@ -219,7 +218,8 @@ describe("DOI form", function () {
 
       // Open the DOI form again and check the fields render correctly
       cy.get("button").contains("Add DOI information (optional)", { timeout: 10000 }).click()
-      cy.get("[data-testid='creators.0.givenName']").should("have.value", "John Smith")
+      cy.get("[data-testid='creators.0.givenName']").should("have.value", "Test given name")
+      cy.get("[data-testid='creators.0.familyName']").should("have.value", "Test family name")
       cy.get("select[data-testid='subjects.0.subject']").should("have.value", "FOS: Mathematics")
       cy.get("div[data-testid='keyword-1']").scrollIntoView().should("be.visible")
       cy.get("div[data-testid='keyword-3']").scrollIntoView().should("be.visible")
@@ -251,14 +251,14 @@ describe("DOI form", function () {
     // Fill in required Creators field
     cy.get("[data-testid='creators']").parent().children("button").click()
     cy.get("[data-testid='creators.0.givenName']").type("Test given name")
+    cy.get("[data-testid='creators.0.familyName']").type("Test family name")
 
     // Fill in required Subjects field
     cy.get("[data-testid='subjects']").parent().children("button").click()
     cy.get("[data-testid='subjects.0.subject']").select("FOS: Mathematics")
 
     // Fill in required Keywords
-    cy.get("[data-testid='keywords']").parent().children("button").click()
-    cy.get("input[data-testid='keywords.0']").type("keyword-1,")
+    cy.get("input[data-testid='keywords']").type("keyword-1,")
 
     // Select Dates
     cy.get("[data-testid='dates']").parent().children("button").click()

--- a/cypress/integration/draft.spec.ts
+++ b/cypress/integration/draft.spec.ts
@@ -54,6 +54,7 @@ describe("Draft operations", function () {
 
     cy.get("[data-testid='descriptor.studyTitle']", { timeout: 10000 }).should("have.value", "New title")
     cy.get("[data-testid='descriptor.studyType']").select("Metagenomics")
+    cy.get("[data-testid='descriptor.studyAbstract']").type("New abstract")
     cy.get("button[type=button]").contains("Update draft").click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft updated with")
 
@@ -63,6 +64,7 @@ describe("Draft operations", function () {
     cy.get("[data-testid='descriptor.studyTitle']").type("New title 2")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "New title 2")
     cy.get("[data-testid='descriptor.studyType']").select("Resequencing")
+    cy.get("[data-testid='descriptor.studyAbstract']").type("New abstract 2")
     cy.formActions("Save as Draft")
 
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
@@ -76,16 +78,8 @@ describe("Draft operations", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Submitted with")
     cy.get("[data-testid='Form-objects']").find("li").should("have.length", 1)
 
-    // Submit second form draft
-    cy.get("[data-testid='Draft-objects']").find("li").should("have.length", 1)
-
-    cy.continueFirstDraft()
-    cy.formActions("Submit")
-    // Check that there are 2 submitted objects
-    cy.get("[data-testid='Form-objects']", { timeout: 10000 }).find("li").should("have.length", 2)
-
     // Drafts list should be unmounted
-    cy.get("[data-testid='Draft-objects']").should("not.exist")
+    cy.get("[data-testid='Draft-objects']").should("have.length", 1)
   })
 })
 

--- a/cypress/integration/draftTemplates.spec.ts
+++ b/cypress/integration/draftTemplates.spec.ts
@@ -14,7 +14,7 @@ describe("draft selections and templates", function () {
     cy.get("[data-testid='descriptor.studyTitle']").type("Study test title")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Study test title")
     cy.get("[data-testid='descriptor.studyType']").select("Metagenomics")
-
+    cy.get("[data-testid='descriptor.studyAbstract']").type("Study test abstract")
     // Submit Study form
     cy.formActions("Submit")
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
@@ -38,8 +38,18 @@ describe("draft selections and templates", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
     cy.get("[data-testid='Draft-objects']").find("li").should("have.length", 1)
 
+    // Fill Dataset form
+    cy.clickFillForm("Dataset")
+    cy.get("[data-testid='title']").type("Test Dataset title")
+    cy.get("[data-testid='description']").type("Dataset description")
+    cy.get("[data-testid='datasetType']").first().check()
+    cy.formActions("Submit")
+
     // Navigate to summary
     cy.get("button[type=button]").contains("Next").click()
+
+    // Fill and save DOI form
+    cy.saveDoiForm()
 
     // Navigate to publish button at the bottom
     cy.get("button[type=button]").contains("Publish").click()

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -20,7 +20,7 @@ describe("Home e2e", function () {
     cy.clickFillForm("Study")
     cy.get("input[data-testid='descriptor.studyTitle']").type("Test title")
     cy.get("select[data-testid='descriptor.studyType']").select("Resequencing")
-
+    cy.get("[data-testid='descriptor.studyAbstract']").type("Test abstract")
     // Save draft
     cy.formActions("Save as Draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
@@ -80,8 +80,17 @@ describe("Home e2e", function () {
     cy.get("div[role=button]").contains("Fill Form").click()
     cy.get("input[data-testid='descriptor.studyTitle']").type("Test title")
     cy.get("select[data-testid='descriptor.studyType']").select("Resequencing")
+    cy.get("[data-testid='descriptor.studyAbstract']").type("Test abstract")
 
     // Submit form
+    cy.formActions("Submit")
+    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+
+    // Fill Dataset form
+    cy.clickFillForm("Dataset")
+    cy.get("[data-testid='title']").type("Test Dataset title")
+    cy.get("[data-testid='description']").type("Dataset description")
+    cy.get("[data-testid='datasetType']").first().check()
     cy.formActions("Submit")
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
@@ -90,6 +99,9 @@ describe("Home e2e", function () {
     cy.get("h1", { timeout: 10000 }).contains("Summary").should("be.visible")
     // Check the amount of submitted objects in Study
     cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
+
+    // Fill and save DOI form
+    cy.saveDoiForm()
 
     // Navigate to publish
     cy.get("button[type=button]").contains("Publish").click()

--- a/cypress/integration/objectLinksAttributes.spec.ts
+++ b/cypress/integration/objectLinksAttributes.spec.ts
@@ -20,6 +20,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='descriptor.studyTitle']").type("Test title")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Test title")
     cy.get("select[data-testid='descriptor.studyType']").select("Metagenomics")
+    cy.get("[data-testid='descriptor.studyAbstract']").type("Test abstract")
 
     // Add new Study Link
     cy.get("div").contains("Study Links").parents().children("button").click()
@@ -57,12 +58,12 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyAttributes.0.tag']").type("Test Attributes Tag")
     cy.get("[data-testid='studyAttributes.0.value']").type("Test Attributes Value")
 
-    // Submit form
-    cy.formActions("Submit")
+    // Save as draft
+    cy.formActions("Save as Draft")
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
-    // Check submitted object has correnct rendering data
-    cy.get("button[type=button]").contains("Edit").click()
+    // Check saved object has correnct rendering data
+    cy.get("button[type=button]").contains("Continue").click()
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Test title")
 
     // Check XRef Link
@@ -97,7 +98,7 @@ describe("render objects' links and attributes ", function () {
 
     // Test that removed link item is removed also from backend
     cy.formActions("Update")
-    cy.get("button[type=button]").contains("Edit").click()
+    cy.get("button[type=button]").contains("Continue").click()
     cy.get("div[data-testid='studyLinks'] > div", { timeout: 30000 }).should("have.length", 2)
   })
 })

--- a/cypress/integration/objectTitles.spec.ts
+++ b/cypress/integration/objectTitles.spec.ts
@@ -10,49 +10,39 @@ describe("draft and submitted objects' titles", function () {
 
   it("should show correct Submitted object's displayTitle", () => {
     // Focus on the Study title input in the Study form (not type anything)
-    cy.get("div[role=button]")
-      .contains("Study")
-      .should("be.visible")
-      .then($el => $el.click())
-    cy.get("div[role=button]").contains("Fill Form").click()
+    cy.clickFillForm("Sample")
 
-    // Variables
-    cy.get("[data-testid='descriptor.studyTitle']").as("studyTitle")
-
-    // Fill a Study form and submit object
-    cy.get("@studyTitle").type("Test title")
-    cy.get("@studyTitle").should("have.value", "Test title")
-    cy.get("select[data-testid='descriptor.studyType']").select("Metagenomics")
-
+    cy.get("[data-testid='title']").type("Sample test title").as("sampleTitle")
+    cy.get("[data-testid='sampleName.taxonId']").type("123")
     // Submit form
     cy.formActions("Submit")
     cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
 
     // Check the submitted object has correct displayTitle
-    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title")
+    cy.get("div[data-schema='sample']", { timeout: 10000 }).should("contain.text", "Sample test title")
 
     // Edit submitted object
     cy.get("button[type=button]").contains("Edit").click()
 
     cy.scrollTo("top")
-    cy.contains("Update Study", { timeout: 10000 }).should("be.visible")
-    cy.get("@studyTitle", { timeout: 10000 }).should("have.value", "Test title")
-    cy.get("@studyTitle", { timeout: 10000 }).type(" 2")
+    cy.contains("Update Sample", { timeout: 10000 }).should("be.visible")
+    cy.get("@sampleTitle", { timeout: 10000 }).should("have.value", "Sample test title")
+    cy.get("@sampleTitle", { timeout: 10000 }).type(" 2")
 
-    cy.get("@studyTitle", { timeout: 30000 }).should("have.value", "Test title 2")
+    cy.get("@sampleTitle", { timeout: 30000 }).should("have.value", "Sample test title 2")
     cy.get("button[type=submit]").contains("Update", { timeout: 10000 }).click()
     cy.get("div[role=alert]").contains("Object updated")
 
     // Check the submitted object has correctly updated displayTitle
-    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+    cy.get("div[data-schema='sample']", { timeout: 10000 }).should("contain.text", "Sample test title 2")
 
     // Navigate to summary
     cy.get("button[type=button]").contains("Next").click()
 
     cy.get("h1", { timeout: 10000 }).contains("Summary").should("be.visible")
     // Check the submitted object has correct displayTitle
-    cy.get("h6").contains("Study").parent("div").children().eq(1).should("have.text", 1)
-    cy.get("div[data-schema='study']", { timeout: 10000 }).should("contain.text", "Test title 2")
+    cy.get("h6").contains("Sample").parent("div").children().eq(1).should("have.text", 1)
+    cy.get("div[data-schema='sample']", { timeout: 10000 }).should("contain.text", "Sample test title 2")
   })
 
   it("should show correct Draft object's displayTitle", () => {
@@ -64,6 +54,7 @@ describe("draft and submitted objects' titles", function () {
     cy.get("[data-testid='descriptor.studyTitle']").type("Draft title")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Draft title")
     cy.get("select[data-testid='descriptor.studyType']").select("Metagenomics")
+    cy.get("[data-testid='descriptor.studyAbstract']").type("Draft abstract")
 
     // Save a draft
     cy.formActions("Save as Draft")

--- a/cypress/integration/pagination.spec.ts
+++ b/cypress/integration/pagination.spec.ts
@@ -259,11 +259,10 @@ describe("unpublished folders, published folders, and user's draft templates pag
     cy.get("[data-testid='page info']").contains("2 of 10 pages", { timeout: 10000 }).should("be.visible")
     // Check "Items per page" options
     cy.wait(0)
-    cy.get("@button")
-      .then($el => {
-        expect(Cypress.dom.isAttached($el).valueOf()).to.be.true
-      })
-      .click()
+    cy.get("@button").then($el => {
+      expect(Cypress.dom.isAttached($el).valueOf()).to.be.true
+    })
+    cy.get("@button").click()
 
     cy.get("li[data-value='5']", { timeout: 10000 }).should("be.visible")
     cy.get("li[data-value='15']").should("be.visible")

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -131,15 +131,14 @@ Cypress.Commands.add("saveDoiForm", () => {
   cy.get("button").contains("Add DOI information (optional)").click()
   // Fill in required Creators field
   cy.get("[data-testid='creators']").parent().children("button").click()
-  cy.get("[data-testid='creators.0.givenName']", { timeout: 10000 }).type("John Smith")
-
+  cy.get("[data-testid='creators.0.givenName']", { timeout: 10000 }).type("Test given name")
+  cy.get("[data-testid='creators.0.familyName']", { timeout: 10000 }).type("Test given name")
   // Fill in required Subjects field
   cy.get("[data-testid='subjects']").parent().children("button").click()
   cy.get("select[data-testid='subjects.0.subject']", { timeout: 10000 }).select("FOS: Mathematics")
 
   // Fill in required Keywords
-  cy.get("[data-testid='keywords']").parent().children("button").click()
-  cy.get("input[data-testid='keywords.0']", { timeout: 10000 }).type("keyword-1,")
+  cy.get("input[data-testid='keywords']", { timeout: 10000 }).type("keyword-1,")
 
   cy.get("button[type='submit']").click()
   cy.contains(".MuiAlert-message", "DOI form has been saved successfully")

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -37,6 +37,7 @@ declare global {
       continueFirstDraft(): Chainable<Element>
       openDOIForm(): Chainable<Element>
       formActions(buttonName: string): Chainable<Element>
+      saveDoiForm(): Chainable<Element>
     }
   }
 }
@@ -123,4 +124,23 @@ Cypress.Commands.add("formActions", buttonName => {
   cy.scrollTo("top")
   cy.get("button").contains(buttonName, { timeout: 10000 }).should("be.visible")
   cy.get("button").contains(buttonName, { timeout: 10000 }).click({ force: true })
+})
+
+// Fill required fields to submit DOI form
+Cypress.Commands.add("saveDoiForm", () => {
+  cy.get("button").contains("Add DOI information (optional)").click()
+  // Fill in required Creators field
+  cy.get("[data-testid='creators']").parent().children("button").click()
+  cy.get("[data-testid='creators.0.givenName']", { timeout: 10000 }).type("John Smith")
+
+  // Fill in required Subjects field
+  cy.get("[data-testid='subjects']").parent().children("button").click()
+  cy.get("select[data-testid='subjects.0.subject']", { timeout: 10000 }).select("FOS: Mathematics")
+
+  // Fill in required Keywords
+  cy.get("[data-testid='keywords']").parent().children("button").click()
+  cy.get("input[data-testid='keywords.0']", { timeout: 10000 }).type("keyword-1,")
+
+  cy.get("button[type='submit']").click()
+  cy.contains(".MuiAlert-message", "DOI form has been saved successfully")
 })

--- a/src/components/Home/SubmissionDataTable.tsx
+++ b/src/components/Home/SubmissionDataTable.tsx
@@ -123,24 +123,28 @@ const SubmissionDataTable: React.FC<SubmissionDataTableProps> = props => {
       type: "actions",
       hide: folderType === FolderSubmissionStatus.published,
       getActions: (params: GridRowParams) => [
-        <div key={params.id} data-testid="edit-draft-submission">
+        <>
           <GridActionsCellItem
+            key={params.id}
             icon={<EditIcon color="primary" fontSize="large" />}
             onClick={e => handleEditSubmission(e, params.id)}
             label="Edit"
             showInMenu
+            data-testid="edit-draft-submission"
           />
-        </div>,
-        <div key={params.id} data-testid="delete-draft-submission">
+        </>,
+        <>
           <GridActionsCellItem
+            key={params.id}
             icon={<DeleteIcon color="primary" fontSize="large" />}
             onClick={e => {
               handleDeleteSubmission(e, params.id)
             }}
             label="Delete"
+            data-testid="delete-draft-submission"
             showInMenu
           />
-        </div>,
+        </>,
       ],
     },
   ]

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -1282,18 +1282,30 @@ const FormTagField = ({
             control={control}
             defaultValue={defaultValue}
             render={({ field, fieldState: { error } }) => {
+              const handleKeywordAsTag = (keyword: string) => {
+                // newTags with unique values
+                const newTags = !tags.includes(keyword) ? [...tags, keyword] : tags
+                setTags(newTags)
+                setInputValue("")
+                // Convert tags to string for hidden registered input's values
+                field.onChange(newTags.join(","))
+              }
+
               const handleKeyDown = e => {
                 const { key } = e
                 const trimmedInput = inputValue.trim()
                 // Convert to tags if users press "," OR "Enter"
                 if ((key === "," || key === "Enter") && trimmedInput.length > 0) {
                   e.preventDefault()
-                  // newTags with unique values
-                  const newTags = !tags.includes(trimmedInput) ? [...tags, trimmedInput] : tags
-                  setTags(newTags)
-                  setInputValue("")
-                  // Convert tags to string for hidden registered input's values
-                  field.onChange(newTags.join(","))
+                  handleKeywordAsTag(trimmedInput)
+                }
+              }
+
+              // Convert to tags when user clicks outside of input field
+              const handleOnBlur = () => {
+                const trimmedInput = inputValue.trim()
+                if (trimmedInput.length > 0) {
+                  handleKeywordAsTag(trimmedInput)
                 }
               }
 
@@ -1331,6 +1343,7 @@ const FormTagField = ({
                       value={inputValue}
                       onChange={handleInputChange}
                       onKeyDown={handleKeyDown}
+                      onBlur={handleOnBlur}
                     />
                     {description && (
                       <FieldTooltip title={description} placement="top" arrow>

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -1554,7 +1554,7 @@ const FormArray = ({ object, path, required, description }: FormArrayProps & { d
 
   return (
     <div className="array" key={`${name}-array`} aria-labelledby={name} data-testid={name}>
-      {required && !isValid && <input hidden={true} value="" {...register(name)} />}
+      {required && !isValid && <input hidden={true} value="form-array-required" {...register(name)} />}
       <Typography
         key={`${name}-header`}
         variant={`h${level}` as Variant}

--- a/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/NewDraftWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -656,6 +656,8 @@ const FormTextField = ({
   let watchAutocompleteFieldName = ""
   let prefilledValue: null | undefined = null
 
+  // Case: DOI form - Check if it's <creators>'s and <contributors>'s FullName field in DOI form
+  const isFullNameField = (path[0] === "creators" || path[0] === "contributors") && path[2] === "name"
   let fullNameValue = "" // Case: DOI form - Creators and Contributors' FullName
 
   let disabled = false // boolean if inputValue is disabled
@@ -671,8 +673,6 @@ const FormTextField = ({
     prefilledValue = watchAutocompleteFieldName ? get(watchValues, watchAutocompleteFieldName) : null
 
     // If it's <creators>'s and <contributors>'s FullName field, watch the values of GivenName and FamilyName
-    const isFullNameField = (path[0] === "creators" || path[0] === "contributors") && path[2] === "name"
-
     if (isFullNameField) {
       const givenName = getPathName(path, "givenName")
       const givenNameValue = get(watchValues, givenName) || ""
@@ -692,7 +692,6 @@ const FormTextField = ({
   /*
    * Handle DOI form values
    */
-
   const { setValue, getValues } = useFormContext()
 
   // Check value of current name path
@@ -711,6 +710,11 @@ const FormTextField = ({
   useEffect(() => {
     if (prefilledValue === undefined && val && lastPathItem === prefilledFields[0] && openedDoiForm) setValue(name, "")
   }, [prefilledValue])
+
+  useEffect(() => {
+    // Set value of <creators>'s and <contributors>'s FullName field with the fullNameValue from givenName and familyName
+    if (isFullNameField && fullNameValue) setValue(name, fullNameValue)
+  }, [isFullNameField, fullNameValue])
 
   return (
     <ConnectForm>
@@ -1243,8 +1247,8 @@ const FormAutocompleteField = ({
 }
 
 const ValidationTagField = styled(TextField)(({ theme }) => ({
-  "& .MuiOutlinedInput-root.MuiInputBase-root": { flexWrap: "wrap", padding: "1rem" },
-  "& input": { flex: 1, padding: 0, minWidth: "2rem" },
+  "& .MuiOutlinedInput-root.MuiInputBase-root": { flexWrap: "wrap" },
+  "& input": { flex: 1, minWidth: "2rem" },
   "& label": { color: theme.palette.primary.main },
   "& .MuiOutlinedInput-notchedOutline, div:hover .MuiOutlinedInput-notchedOutline": highlightStyle(theme),
 }))
@@ -1312,18 +1316,21 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
                   <input hidden={true} {...field} />
                   <ValidationTagField
                     InputProps={{
-                      startAdornment: tags.map(item => (
-                        <Chip
-                          key={item}
-                          tabIndex={-1}
-                          label={item}
-                          onDelete={handleTagDelete(item)}
-                          color="primary"
-                          deleteIcon={<ClearIcon fontSize="small" />}
-                          data-testid={item}
-                          sx={{ fontSize: "1.4rem", m: "0.5rem" }}
-                        />
-                      )),
+                      startAdornment:
+                        tags.length > 0
+                          ? tags.map(item => (
+                              <Chip
+                                key={item}
+                                tabIndex={-1}
+                                label={item}
+                                onDelete={handleTagDelete(item)}
+                                color="primary"
+                                deleteIcon={<ClearIcon fontSize="small" />}
+                                data-testid={item}
+                                sx={{ fontSize: "1.4rem", m: "0.5rem" }}
+                              />
+                            ))
+                          : null,
                     }}
                     inputProps={{ "data-testid": name }}
                     label={`${label} *`}

--- a/src/constants/wizardObject.ts
+++ b/src/constants/wizardObject.ts
@@ -34,4 +34,4 @@ export const ObjectSubmissionTypes = {
 
 export const ObjectSubmissionsArray = [ObjectSubmissionTypes.form, ObjectSubmissionTypes.xml]
 
-export const OmitObjectValues = ["accessionId", "dateCreated", "dateModified", "publishDate"]
+export const OmitObjectValues = ["accessionId", "dateCreated", "dateModified", "publishDate", "metaxIdentifier", "doi"]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,7 +126,7 @@ export type ConnectFormChildren = { children: (...args: ConnectFormMethods[]) =>
 
 export type NestedField = {
   id: string
-  fieldValues: Record<string, unknown>
+  fieldValues: string
 }
 
 // ApiSauce uses "any" as argument for response type

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -111,7 +111,7 @@ const Login: React.FC = () => {
               +358 9 457 2821
             </Typography>
           </Box>
-          <Box sx={{ display: "flex" }}>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
             <MailOutlineIcon fontSize="small" />
             <Typography variant="body2" component="span">
               servicedesk@csc.fi


### PR DESCRIPTION
### Description

- `Keywords` is a mandatory field in DOI form and users can type and save as many `keywords` as possible. Keywords are displayed in the form of tags so after typing some text, users should press `,` or `Enter` to mark the keyword as a tag.
-  Fix integration tests for `Study` object, now `Study` form has a mandatory `Study Abstract` field and we can only submit one `Study` object.

### Related issues

Solves https://github.com/CSCfi/metadata-submitter-frontend/issues/628 and https://github.com/CSCfi/metadata-submitter-frontend/issues/695

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

- In `WizardJSONSchemaParser.tsx`, MUI Chip component was used to render `Keywords` field. A hidden `input` is used to register value to the form and MUI Textfield is used to receive input text from user.
- Updated Cypress tests to include:
  - `Study Abstraction` when filling a Study form and only one Study form is submitted per time.
  - `Dataset` object is mandatorily submitted before publishing a submission
  - `DOI` form is also saved before publishing a submission. A Cypress command `saveDoiForm` is added to be reused.

### Testing

- [x] Integration Tests

