### PR TITLE
Target backend develop branch in E2E workflow

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,7 +22,7 @@ jobs:
           if [[ $BRANCH == master ]]; then
              echo "VERSION=master" >> $GITHUB_ENV
           else
-             echo "VERSION=feature/project-ownership" >> $GITHUB_ENV
+             echo "VERSION=develop" >> $GITHUB_ENV
           fi
       - name: Clone backend
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description

Merging #696 before merging [backend feature branch](https://github.com/CSCfi/metadata-submitter/pull/346) caused frontend workflow to target E2E test into backend feature branch. This backend branch is now merged and therefore target branch for workflow should be `develop` branch of backend.

### Related issues

Closes  #727 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Updated E2E workflow backend target branch

