### PR TITLE
Catch the error for not filling Keywords in DOI form

### DIFF
--- a/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -1276,8 +1276,7 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
             name={name}
             control={control}
             defaultValue={defaultValue}
-            rules={{ required: true }}
-            render={({ field, formState }) => {
+            render={({ field }) => {
               const handleKeywordAsTag = (keyword: string) => {
                 // newTags with unique values
                 const newTags = !tags.includes(keyword) ? [...tags, keyword] : tags
@@ -1313,7 +1312,11 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
 
               return (
                 <div className={classes.divBaseline}>
-                  <input hidden={true} {...field} />
+                  <input
+                    {...field}
+                    required={required}
+                    style={{ width: 0, opacity: 0, transform: "translate(8rem, 2rem)" }}
+                  />
                   <ValidationTagField
                     InputProps={{
                       startAdornment:
@@ -1340,13 +1343,11 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
                     onKeyDown={handleKeyDown}
                     onBlur={handleOnBlur}
                   />
+
                   {description && (
                     <FieldTooltip title={description} placement="top" arrow>
                       <HelpOutlineIcon className={classes.fieldTip} />
                     </FieldTooltip>
-                  )}
-                  {required && formState.isSubmitted && !formState.isValid && tags.length === 0 && (
-                    <FormHelperText error>must have at least 1 keyword</FormHelperText>
                   )}
                 </div>
               )


### PR DESCRIPTION
### Description

Saving DOI form without filling required `Keywords` field should show error in the form and not being redirected to error page 400.

### Related issues

Fixes https://github.com/CSCfi/metadata-submitter-frontend/issues/790

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Modify `FormTagField` to catch error correctly when they Keyword field is not filled.

### Testing

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Tests do not apply
- [ ] Needs testing (start an issue or do a follow up PR about it)


