### PR TITLE
Feature/form and xml changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Modified Form layout, Tooltip and Upload XML according to new UI design #811
 - Change url of ROR from http to https #813
 - Refactor **folder** -> **submission** #807
 - Renamed "NewDraft" to "Submission" to all existing components and routes and related tests.

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -180,7 +180,7 @@ describe("Basic application flow", function () {
       cy.get("select[data-testid='analysisType']").select("Reference Alignment")
       cy.get("select[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
       cy.get("[data-testid='analysisType.referenceAlignment.assembly.accession']").type("Standard Accession version")
-      cy.get("h5").contains("Sequence").parents().children("button").click()
+      cy.get("div[data-testid='analysisType.referenceAlignment.sequence'] > div").eq(1).children("button").click()
       cy.get("[data-testid='analysisType.referenceAlignment.sequence.0.accession']").type(
         "Sequence Standard Accession Id"
       )
@@ -209,19 +209,19 @@ describe("Basic application flow", function () {
       cy.get("[data-testid='runRef.0.identifiers.submitterId.value']").type("Run Test Value")
 
       // Analysis
-      cy.get("h5").contains("Analysis Reference").parents().children("button").click()
+      cy.get("div[data-testid='analysisRef'] > div").eq(1).children("button").click()
       cy.get("[data-testid='analysisRef.0.accessionId']").type("Analysis Test Accession Id")
       cy.get("[data-testid='analysisRef.0.identifiers.submitterId.namespace']").type("Analysis Test Namespace")
       cy.get("[data-testid='analysisRef.0.identifiers.submitterId.value']").type("Analysis Test Value")
 
       // Files
-      cy.get("h5").contains("Files").parents().children("button").click()
+      cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
       cy.get("[data-testid='files.0.filename']").type("filename 1")
       cy.get("select[data-testid='files.0.filetype']").select("other")
       cy.get("select[data-testid='files.0.checksumMethod']").select("MD5")
       cy.get("[data-testid='files.0.checksum']").type("b1f4f9a523e36fd969f4573e25af4540")
 
-      cy.get("h5").contains("Files").parents().children("button").click()
+      cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
       cy.get("[data-testid='files.1.filename']").type("filename 2")
       cy.get("select[data-testid='files.1.filetype']").select("info")
       cy.get("select[data-testid='files.1.checksumMethod']").select("SHA-256")

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -28,7 +28,7 @@ describe("Basic application flow", function () {
      */
 
     // Try to send invalid form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     cy.get<FormInput[]>("input[data-testid='descriptor.studyTitle']").then($input => {
       expect($input[0].validationMessage).to.contain("Please fill")
@@ -38,7 +38,7 @@ describe("Basic application flow", function () {
     cy.get("[data-testid='descriptor.studyTitle']").type("Test title")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "Test title")
 
-    cy.formActions("Clear form")
+    cy.optionsActions("Clear form")
 
     cy.get("[data-testid='descriptor.studyTitle']").type("New title")
     cy.get("[data-testid='descriptor.studyTitle']").should("have.value", "New title")
@@ -46,7 +46,7 @@ describe("Basic application flow", function () {
     cy.get("[data-testid='descriptor.studyAbstract']").type("New abstract")
 
     // Submit form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
     cy.get("[data-testid='study-objects-list']").find("li").should("have.length", 1)
 
     // DAC form
@@ -54,10 +54,10 @@ describe("Basic application flow", function () {
 
     // Try to submit empty DAC form. This should be invalid
     cy.get("[data-testid=title]").type("Test title")
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
     cy.get("span").contains("must have at least 1 item")
 
-    cy.get("h5").contains("Contacts").parents().children("button").click()
+    cy.get("div[data-testid='contacts'] > div > button").click()
     cy.get("[data-testid='contacts.0.name']").type("Test contact name")
     // Test invalid email address (form array, default)
     cy.get("[data-testid='contacts.0.email']").type("email")
@@ -71,11 +71,11 @@ describe("Basic application flow", function () {
     cy.get("[data-testid='contacts.0.mainContact']").check()
 
     // Submit DAC form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Test DAC form update
     cy.get("[data-testid='dac-objects-list']").within(() => {
-      cy.get("a").contains("Test contact name").click()
+      cy.get("a").contains("Test title").click()
     })
 
     cy.get("[data-testid='contacts']").should("be.visible")
@@ -86,7 +86,7 @@ describe("Basic application flow", function () {
     cy.formActions("Update")
 
     cy.get("[data-testid='dac-objects-list']").within(() => {
-      cy.get("a").contains("Test contact name").click()
+      cy.contains("Test title").should("be.visible").click({ force: true })
     })
     cy.get("[data-testid='contacts.0.name']").should("have.value", "Test contact name edited")
 
@@ -101,7 +101,7 @@ describe("Basic application flow", function () {
     cy.get("textarea[data-testid='policy.policyText']").type("Test policy text")
 
     // Submit Policy form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     /*
      * 3rd step, Describe
@@ -121,7 +121,7 @@ describe("Basic application flow", function () {
     cy.get("[data-testid='title']").type("Test Sample title")
     cy.get("[data-testid='sampleName.taxonId']").type("123")
     // Submit Sample form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Fill a Experiment form
     cy.clickAddObject(ObjectTypes.experiment)
@@ -155,12 +155,12 @@ describe("Basic application flow", function () {
     )
 
     // Submit Experiment form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Fill a Run form
     cy.clickAddObject(ObjectTypes.run)
     cy.get("[data-testid='title']").type("Test Run title")
-    cy.get("h5[data-testid='experimentRef']").parents().children("button").click()
+    cy.get("[data-testid='experimentRef'] > div > button").click()
 
     // Select experimentAccessionId
     cy.get("select[data-testid='experimentRef.0.accessionId']").select(1)
@@ -168,7 +168,7 @@ describe("Basic application flow", function () {
     cy.get("select[data-testid='experimentRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Run form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Fill an Analysis form
     cy.clickAddObject(ObjectTypes.analysis)
@@ -197,31 +197,31 @@ describe("Basic application flow", function () {
       cy.get("[data-testid='experimentRef.refname']").type("Experiment Test Namespace")
 
       // Sample
-      cy.get("h5").contains("Sample Reference").parents().children("button").click()
+      cy.get("[data-testid='sampleRef'] > div > button").click()
       cy.get("[data-testid='sampleRef.0.accessionId']").select(1)
       cy.get("[data-testid='sampleRef.0.identifiers.submitterId.namespace']").type("Sample Test Namespace")
       cy.get("[data-testid='sampleRef.0.identifiers.submitterId.value']").type("Sample Test Value")
 
       // Run
-      cy.get("h5").contains("Run Reference").parents().children("button").click()
+      cy.get("[data-testid='runRef'] > div > button").click()
       cy.get("[data-testid='runRef.0.accessionId']").select(1)
       cy.get("[data-testid='runRef.0.identifiers.submitterId.namespace']").type("Run Test Namespace")
       cy.get("[data-testid='runRef.0.identifiers.submitterId.value']").type("Run Test Value")
 
       // Analysis
-      cy.get("div[data-testid='analysisRef'] > div").eq(1).children("button").click()
+      cy.get("[data-testid='analysisRef'] > div > button").click()
       cy.get("[data-testid='analysisRef.0.accessionId']").type("Analysis Test Accession Id")
       cy.get("[data-testid='analysisRef.0.identifiers.submitterId.namespace']").type("Analysis Test Namespace")
       cy.get("[data-testid='analysisRef.0.identifiers.submitterId.value']").type("Analysis Test Value")
 
       // Files
-      cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
+      cy.get("[data-testid='files'] > div > button").click()
       cy.get("[data-testid='files.0.filename']").type("filename 1")
       cy.get("select[data-testid='files.0.filetype']").select("other")
       cy.get("select[data-testid='files.0.checksumMethod']").select("MD5")
       cy.get("[data-testid='files.0.checksum']").type("b1f4f9a523e36fd969f4573e25af4540")
 
-      cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
+      cy.get("[data-testid='files'] > div > button").click()
       cy.get("[data-testid='files.1.filename']").type("filename 2")
       cy.get("select[data-testid='files.1.filetype']").select("info")
       cy.get("select[data-testid='files.1.checksumMethod']").select("SHA-256")
@@ -230,7 +230,7 @@ describe("Basic application flow", function () {
       )
     })
     // Submit Analysis form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Fill a Dataset form
     cy.clickAddObject(ObjectTypes.dataset)
@@ -244,17 +244,17 @@ describe("Basic application flow", function () {
     cy.get("select[data-testid='policyRef.accessionId']").should("contain", " - Title:")
 
     // Select runAccessionId
-    cy.get("div").contains("Run Reference").parents().children("button").click()
+    cy.get("[data-testid='runRef'] > div > button").click()
     cy.get("select[data-testid='runRef.0.accessionId']").select(1)
     cy.get("select[data-testid='runRef.0.accessionId']").should("contain", " - Title:")
 
     // Select analysisAccessionId
-    cy.get("div").contains("Analysis Reference").parents().children("button").click()
+    cy.get("[data-testid='analysisRef'] > div > button").click()
     cy.get("select[data-testid='analysisRef.0.accessionId']").select(1)
     cy.get("select[data-testid='analysisRef.0.accessionId']").should("contain", " - Title:")
 
     // Submit Dataset form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     /*
      * 5th step, Identifier and publish

--- a/cypress/integration/doiForm.spec.ts
+++ b/cypress/integration/doiForm.spec.ts
@@ -30,7 +30,7 @@ describe("DOI form", function () {
       checksumMethod: "MD5",
       checksum: "Run file check sum",
     }
-    cy.get("[data-testid='files']").parents().children("button").click()
+    cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
     cy.get("[data-testid='files.0.filename']").type(testRunFile.fileName)
     cy.get("[data-testid='files.0.filetype']").select(testRunFile.fileType)
     cy.get("[data-testid='files.0.checksumMethod']").select(testRunFile.checksumMethod)
@@ -66,7 +66,7 @@ describe("DOI form", function () {
       checksum: "Analysis file check sum",
     }
     // Select fileType
-    cy.get("[data-testid='files']").parents().children("button").click()
+    cy.get("div[data-testid='files'] > div").eq(1).children("button").click()
     cy.get("[data-testid='files.0.filename']").type(testAnalysisFile.fileName)
     cy.get("[data-testid='files.0.filetype']").select(testAnalysisFile.fileType1)
     cy.get("[data-testid='files.0.checksumMethod']").select(testAnalysisFile.checksumMethod)
@@ -104,8 +104,8 @@ describe("DOI form", function () {
     cy.get("[data-testid='formats.1']", { timeout: 10000 }).should("have.value", "cram")
 
     // Go to Creators section and Add new item
-    cy.get("[data-testid='creators']").parents().children("button").click()
-    cy.get("[data-testid='creators.0.affiliation']", { timeout: 10000 }).parent().children("button").click()
+    cy.get("div[data-testid='creators'] > div").eq(1).children("button").click()
+    cy.get("div[data-testid='creators.0.affiliation'] > div").eq(1).children("button").click()
 
     // Type search words in autocomplete field
     cy.intercept("/organizations*").as("searchOrganization")
@@ -130,12 +130,11 @@ describe("DOI form", function () {
 
     // Remove Creators > Affiliations field and add a new field again
     cy.get("div[data-testid='creators.0.affiliation'] > div").children("button").click()
-    cy.get("h4[data-testid='creators.0.affiliation']").parent().children("button").click()
 
     // Repeat search words in autocomplete field
     cy.get("[data-testid='creators.0.affiliation.0.name-inputField']").type("csc")
     // Select the first result
-    cy.get(".MuiAutocomplete-option")
+    cy.get(".MuiAutocomplete-popper")
       .should("be.visible")
       .then($el => $el.first().click())
 
@@ -153,8 +152,9 @@ describe("DOI form", function () {
     cy.get("[data-testid='creators.0.affiliation.0.affiliationIdentifierScheme']").should("be.disabled")
 
     // Go to Contributors and Add new item
-    cy.get("[data-testid='contributors']").parents().children("button").click()
-    cy.get("[data-testid='contributors.0.affiliation']", { timeout: 10000 }).parent().children("button").click()
+    cy.get("div[data-testid='contributors'] > div").children("button").click()
+    cy.get("div[data-testid='contributors.0.affiliation'] > div").children("button").click()
+
     // Type search words in autocomplete field
     cy.get("[data-testid='contributors.0.affiliation.0.name-inputField']").type("demos")
     // Select the first result
@@ -196,10 +196,10 @@ describe("DOI form", function () {
       // Go to DOI form
       cy.openDOIForm()
       // Fill in required Creators field
-      cy.get("[data-testid='creators']").parent().children("button").click()
+      cy.get("div[data-testid='creators'] > div").eq(1).children("button").click()
       cy.get("[data-testid='creators.0.givenName']").type("Test given name")
       cy.get("[data-testid='creators.0.familyName']").type("Test family name")
-      cy.get("[data-testid='creators.0.affiliation']", { timeout: 10000 }).parent().children("button").click()
+      cy.get("div[data-testid='creators.0.affiliation'] > div").eq(1).children("button").click()
       cy.intercept("/organizations*").as("searchOrganization")
       cy.get("[data-testid='creators.0.affiliation.0.name-inputField']").type("csc")
       cy.wait("@searchOrganization")
@@ -208,7 +208,7 @@ describe("DOI form", function () {
         .then($el => $el.first().click())
       cy.get("[data-testid='creators.0.affiliation.0.schemeUri']").should("have.value", "https://ror.org")
       // Fill in required Subjects field
-      cy.get("[data-testid='subjects']").parent().children("button").click()
+      cy.get("div[data-testid='subjects'] > div").eq(1).children("button").click()
       cy.get("select[data-testid='subjects.0.subject']").select("FOS: Mathematics")
 
       // Fill in required Keywords
@@ -242,14 +242,14 @@ describe("DOI form", function () {
       // Go to DOI form
       cy.openDOIForm()
       // Go to Creators section and fill in given name, family name
-      cy.get("[data-testid='creators']").parents().children("button").click()
+      cy.get("div[data-testid='creators'] > div").eq(1).children("button").click()
       cy.get("[data-testid='creators.0.givenName']").type("Creator's given name")
       cy.get("[data-testid='creators.0.familyName']").type("Creator's family name")
       // Check full name is autofilled from family name and given name
       cy.get("[data-testid='creators.0.name']").should("have.value", "Creator's family name,Creator's given name")
 
       // Go to Contributors and fill in given name, family name
-      cy.get("[data-testid='contributors']").parents().children("button").click()
+      cy.get("div[data-testid='contributors'] > div").eq(1).children("button").click()
       cy.get("[data-testid='contributors.0.givenName']").type("Contributor's given name")
       cy.get("[data-testid='contributors.0.familyName']").type("Contributor's family name")
       // Check full name is autofilled from family name and given name

--- a/cypress/integration/doiForm.spec.ts
+++ b/cypress/integration/doiForm.spec.ts
@@ -21,7 +21,7 @@ describe("DOI form", function () {
     }
 
     cy.get("[data-testid='title']").type(testRunData.title)
-    cy.get("h5[data-testid='experimentRef']").parents().children("button").click()
+    cy.get("div[data-testid='experimentRef'] > div > button").click()
     cy.get("[data-testid='experimentRef.0.accessionId']").select(1)
 
     const testRunFile = {
@@ -37,7 +37,7 @@ describe("DOI form", function () {
     cy.get("[data-testid='files.0.checksum']").type(testRunFile.checksum)
 
     // Submit form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Run objects container should have contain created object
     cy.get("[data-testid='run-objects-list']").find("li").should("have.length", 2)
@@ -73,13 +73,13 @@ describe("DOI form", function () {
     cy.get("[data-testid='files.0.checksum']").type(testAnalysisFile.checksum)
 
     // Submit form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Analysis objects container should have contain created object
     cy.get("[data-testid='analysis-objects-list']").find("li").should("have.length", 2)
 
     // Fill another Analysis form with the same fileType as Run form: "bam"
-    cy.formActions("New form")
+    cy.get("button").contains("Add analysis").click()
     cy.get("[data-testid='title']").type(testAnalysisData.title2)
     cy.get("[data-testid='analysisType']").select("Reference Alignment")
     cy.get("[data-testid='analysisType.referenceAlignment.assembly']").select("Standard")
@@ -91,7 +91,7 @@ describe("DOI form", function () {
     cy.get("[data-testid='files.0.checksum']").type(testAnalysisFile.checksum)
 
     // Submit form
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
 
     // Analysis objects container should have contain both newly created objects
     cy.get("[data-testid='analysis-objects-list']").find("li").should("have.length", 3)
@@ -265,10 +265,10 @@ describe("DOI form", function () {
       cy.openDOIForm()
 
       // Fill in required Creators field
-      cy.get("[data-testid='creators']").parent().children("button").click()
+      cy.get("div[data-testid='creators'] > div > button").click()
       cy.get("[data-testid='creators.0.givenName']").type("Test given name")
       cy.get("[data-testid='creators.0.familyName']").type("Test family name")
-      cy.get("[data-testid='creators.0.affiliation']", { timeout: 10000 }).parent().children("button").click()
+      cy.get("div[data-testid='creators.0.affiliation'] > div > button").click()
       cy.intercept("/organizations*").as("searchOrganization")
       cy.get("[data-testid='creators.0.affiliation.0.name-inputField']").type("csc")
       cy.wait("@searchOrganization")
@@ -278,14 +278,14 @@ describe("DOI form", function () {
       cy.get("[data-testid='creators.0.affiliation.0.schemeUri']").should("have.value", "https://ror.org")
 
       // Fill in required Subjects field
-      cy.get("[data-testid='subjects']").parent().children("button").click()
+      cy.get("div[data-testid='subjects'] > div > button").click()
       cy.get("[data-testid='subjects.0.subject']").select("FOS: Mathematics")
 
       // Fill in required Keywords
       cy.get("input[data-testid='keywords']").type("keyword-1,")
 
       // Select Dates
-      cy.get("[data-testid='dates']").parent().children("button").click()
+      cy.get("div[data-testid='dates'] > div > button").click()
 
       cy.get("[data-testid='dates.0.date']").scrollIntoView()
       cy.get("[data-testid='dates.0.date']").should("be.visible")

--- a/cypress/integration/draft.spec.ts
+++ b/cypress/integration/draft.spec.ts
@@ -19,14 +19,15 @@ describe("Draft operations", function () {
     cy.get("[data-testid=title]").type("Test title")
 
     // Save a draft
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
     cy.get("[data-testid='policy-objects-list']").find("li").should("have.length", 1)
 
     // Save another draft
-    cy.formActions("New form")
+    cy.get("button").contains("Add policy").click()
+    cy.get("[data-testid=title]").should("have.value", "")
     cy.get("[data-testid=title]").type("Test title 2")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
     cy.get("[data-testid='policy-objects-list']").find("li").should("have.length", 2)
 
@@ -35,23 +36,14 @@ describe("Draft operations", function () {
     cy.get("[data-testid='policy-objects-list']").find("a").first().click()
     cy.get("h2").contains("Would you like to save draft version of this form")
     cy.get("div[role=dialog]").contains("Save").click()
+    cy.get("div[role=dialog]", { timeout: 10000 }).should("not.exist")
     cy.get("[data-testid='policy-objects-list']").find("li").should("have.length", 2)
 
-    // Delete a draft
-    cy.get("[data-testid='Draft-objects']")
-      .find("li")
-      .first()
-      .within(() => {
-        cy.get("[data-testid='Delete submission']").first().click()
-      })
-    cy.get("[data-testid='Draft-objects']").find("li", { timeout: 10000 }).should("have.length", 1)
+    // Continue first draft
+    cy.get("[data-testid='draft-policy-list-item']", { timeout: 10000 }).first().click({ force: true })
 
-    // Continue draft
-    cy.continueLatestDraft(ObjectTypes.policy)
-
-    cy.get("[data-testid=title]")
-    // Clear
-    cy.formActions("Clear form")
+    // Clear form
+    cy.optionsActions("Clear form")
     // Fill
     cy.get("[data-testid=title]").should("have.value", "")
     cy.get("[data-testid=title]").type("New title")
@@ -62,38 +54,33 @@ describe("Draft operations", function () {
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft updated with")
 
     // Create a new form and save as draft
-    cy.formActions("New form")
+    cy.get("button").contains("Add DAC").click()
     cy.get("[data-testid=title]").should("contain.text", "")
     cy.get("[data-testid=title]").type("New title 2")
     cy.get("[data-testid=title]").should("have.value", "New title 2")
-    cy.get("select[data-testid='dacRef.accessionId']").select(1)
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
 
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Check that there are 2 drafts saved in drafts list
-    cy.get("ul[data-testid='Draft-objects']").find("li").should("have.length", 2)
+    cy.get("ul[data-testid='dac-objects-list']").find("li").should("have.length", 2)
 
     // Submit first form draft
     cy.continueLatestDraft(ObjectTypes.policy)
+    cy.get("select[data-testid='dacRef.accessionId']").select(1)
     cy.get("select[data-testid='policy']").select("Policy Text")
     cy.get("textarea[data-testid='policy.policyText']").type("Test policy text")
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Submitted with")
-    cy.get("[data-testid='Form-objects']").find("li").should("have.length", 1)
 
     // Submit second form draft
-    cy.get(`[data-testid='draft-${ObjectTypes.policy}-list-item']`).should("have.length", 1)
     // Re-query instead of continueLatestDraft -command since original query results in detached DOM element
-    cy.get(`[data-testid='draft-${ObjectTypes.policy}-list-item']`).click()
-    cy.get("select[data-testid='policy']").select("Policy Text")
+    cy.get(`[data-testid='draft-${ObjectTypes.policy}-list-item']`).first().click({ force: true })
+    cy.get("select[data-testid='policy']", { timeout: 10000 }).should("be.visible").select("Policy Text")
     cy.get("textarea[data-testid='policy.policyText']").type("Test policy text")
-    cy.formActions("Submit")
+    cy.formActions("Mark as ready")
     // Check that there are 2 submitted objects
-    cy.get("[data-testid='Form-objects']", { timeout: 10000 }).find("li").should("have.length", 2)
-
-    // Drafts list should be unmounted
-    cy.get("[data-testid='Draft-objects']").should("have.length", 0)
+    cy.get("[data-testid='policy-objects-list']", { timeout: 10000 }).find("li").should("have.length", 2)
   })
 })
 

--- a/cypress/integration/draftTemplates.spec.ts
+++ b/cypress/integration/draftTemplates.spec.ts
@@ -12,7 +12,7 @@ describe("draft selections and templates", function () {
     cy.clickAccordionPanel("Study, DAC and Policy")
     cy.clickAddObject("policy")
     cy.get("[data-testid=title]").type("Policy draft title")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
 
     cy.clickAccordionPanel("publish")
 

--- a/cypress/integration/editForm.spec.ts
+++ b/cypress/integration/editForm.spec.ts
@@ -110,7 +110,7 @@ describe("Populate form and render form elements by object data", function () {
       .as("sampleAccessionId")
 
     // Expected Base Call Table
-    cy.get("div").contains("Expected Base Call Table").parents().children("button").click()
+    cy.get("div[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable'] > div").children("button").click()
     cy.get("[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable.0.baseCall']").type("Test base call")
     cy.get("[data-testid='design.spotDescriptor.readSpec.expectedBaseCallTable.0.readGroupTag']").type(
       "Test read group tag"

--- a/cypress/integration/editForm.spec.ts
+++ b/cypress/integration/editForm.spec.ts
@@ -33,11 +33,10 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("select[data-testid='sampleData.gender']").select(testData.gender)
 
     // Submit form
-    cy.get("button[type=submit]").contains("Submit").click()
-    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+    cy.formActions("Mark as ready")
 
     // Clear form
-    cy.get("button[type=button]").contains("Clear").click()
+    cy.optionsActions("Clear form")
 
     // Edit saved submission
     cy.get("[data-testid='sample-objects-list']").within(() => {
@@ -71,9 +70,6 @@ describe("Populate form and render form elements by object data", function () {
     })
     cy.get("select[data-testid='sampleData']").should("have.value", testData.sampleData2)
     cy.get("[data-testid='sampleData.dataDescription']").should("have.value", testData.sampleTypeDescription)
-
-    // Clear object in state
-    cy.formActions("New form")
 
     // Test updated title
     cy.get("[data-testid='sample-objects-list']").find("li").should("have.length", 2)
@@ -117,7 +113,7 @@ describe("Populate form and render form elements by object data", function () {
     )
 
     // Save Experiment form
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     cy.continueLatestDraft(ObjectTypes.experiment)
@@ -160,7 +156,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[data-testid='runType.referenceAlignment.assembly.accession']").type(testData.accessionId)
 
     // Save draft
-    cy.get("button[type='button']").contains("Save as Draft").click()
+    cy.get("button[type='button']").contains("Save as draft").click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Select newly saved draft
@@ -181,7 +177,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[type='checkbox']").first().check()
 
     // Save draft
-    cy.get("button[type='button']").contains("Save as Draft").click()
+    cy.get("button[type='button']").contains("Save as draft").click()
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Select newly saved draft
@@ -190,10 +186,7 @@ describe("Populate form and render form elements by object data", function () {
     cy.get("[type='checkbox']").first().should("be.checked")
 
     // Test that checkbox clears with form clear -button
-    cy.get("button[type=button]")
-      .contains("Clear form")
-      .should("be.visible")
-      .then($el => $el.click())
+    cy.optionsActions("Clear form")
     cy.get("[type='checkbox']").first().should("not.be.checked")
   })
 
@@ -201,17 +194,16 @@ describe("Populate form and render form elements by object data", function () {
     cy.clickAddObject(ObjectTypes.sample)
     cy.get("[data-testid='title']").type("Test sample title")
     // Save draft
-    cy.get("button[type='button']").contains("Save as Draft").click()
+    cy.get("button[type='button']").contains("Save as draft").click()
     // Edit the draft and try to submit invalid form
     cy.continueLatestDraft(ObjectTypes.sample)
-    cy.get("button[type=submit]").contains("Submit").click()
+    cy.formActions("Mark as ready")
     // Taxon field should be empty and the draft cannot be submitted yet
     cy.get("[data-testid='sampleName.taxonId']").should("have.value", "")
-    cy.get("[data-testid='Draft-objects']").should("have.length", 1)
 
     // Fill in taxonId and submit the form again
     cy.get("[data-testid='sampleName.taxonId']").type("123")
-    cy.get("button[type=submit]").contains("Submit").click()
+    cy.formActions("Mark as ready")
 
     // Check that the draft is removed from the draft objects list and submitted
     cy.get(`[data-testid='sample-objects-list']`).within(() => {

--- a/cypress/integration/emptyForm.spec.ts
+++ b/cypress/integration/emptyForm.spec.ts
@@ -1,4 +1,4 @@
-import { DisplayObjectTypes, ObjectTypes } from "constants/wizardObject"
+import { ObjectTypes } from "constants/wizardObject"
 
 describe("empty form should not be alerted or saved", function () {
   beforeEach(() => {
@@ -11,36 +11,30 @@ describe("empty form should not be alerted or saved", function () {
     cy.clickAccordionPanel("Describe")
   })
 
-  it("should have New form button and Clear form button emptied the form", () => {
+  it("should have Clear form button emptied the form", () => {
     // Check Clear form button in Sample object
     cy.clickAddObject(ObjectTypes.sample)
 
     cy.get("input[data-testid='title']").type("Test sample")
     cy.get("input[data-testid='sampleName.taxonId']").type("123")
-    cy.formActions("Clear form")
+    cy.optionsActions("Clear form")
     cy.get("input[data-testid='title']").should("have.value", "")
     cy.get("input[data-testid='sampleName.taxonId']").should("have.value", "")
 
-    // Check both New form button and Clear form button with Experiment object
+    // Check both Clear form button with Experiment object
     cy.clickAddObject(ObjectTypes.experiment)
-
-    // Check if New form button can empty the form
-    cy.get("form")
-    cy.formActions("New form")
-    cy.get("input[data-testid='title']").should("have.value", "")
-    cy.get("textarea[data-testid='description']").should("have.value", "")
 
     // Fill in the form an check if Clear form button can empty the form
     cy.get("input[data-testid='title']").type("Test experiment")
     cy.get("textarea[data-testid='description']").type("Test experiment description")
-    cy.formActions("Clear form")
+    cy.optionsActions("Clear form")
     cy.get("input[data-testid='title']").should("have.value", "")
     cy.get("textarea[data-testid='description']").should("have.value", "")
 
     // Fill in the form again and save as draft
     cy.get("input[data-testid='title']").type("Test experiment")
     cy.get("textarea[data-testid='description']").type("Test experiment description")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Select the Experiment draft
@@ -50,7 +44,7 @@ describe("empty form should not be alerted or saved", function () {
     cy.get("textarea[data-testid='description']").should("have.value", "Test experiment description")
 
     // Click Clear form button and expect the form is empty
-    cy.formActions("Clear form")
+    cy.optionsActions("Clear form")
     cy.get("input[data-testid='title']").should("have.value", "")
     cy.get("textarea[data-testid='description']").should("have.value", "")
 
@@ -59,11 +53,6 @@ describe("empty form should not be alerted or saved", function () {
 
     cy.get("input[data-testid='title']").should("have.value", "Test experiment")
     cy.get("textarea[data-testid='description']").should("have.value", "Test experiment description")
-
-    // Click New form button and expect the form is empty
-    cy.formActions("New form")
-    cy.get("input[data-testid='title']").should("have.value", "")
-    cy.get("textarea[data-testid='description']").should("have.value", "")
   })
 
   it("should not show draft saving alert when form is empty, should not save an empty form", () => {
@@ -72,17 +61,15 @@ describe("empty form should not be alerted or saved", function () {
 
     // Switch to another object type form and Alert window should not pop up
     cy.editLatestSubmittedObject(ObjectTypes.experiment)
-    cy.get("[role='heading']", { timeout: 10000 }).contains(DisplayObjectTypes.experiment).should("be.visible")
-
     // Switch back to Sample form and fill it
     cy.clickAddObject(ObjectTypes.sample)
     cy.get("[data-testid='title']").type("Test Sample title")
     cy.get("[data-testid='sampleName.taxonId']").type("123")
 
     // Clear form and Save
-    cy.formActions("Clear form")
+    cy.optionsActions("Clear form")
     cy.get("input[data-testid='title']", { timeout: 10000 }).should("be.empty")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
 
     // Expect Info window should pop up
     cy.get("div[role=alert]").contains("An empty form cannot be saved.").should("be.visible")
@@ -91,12 +78,12 @@ describe("empty form should not be alerted or saved", function () {
     cy.get("[data-testid='title']").type("Test Sample title")
     cy.get("input[data-testid='title']").should("have.value", "Test Sample title")
 
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]").contains("Draft saved with")
 
     // Clear Study title input and Save
     cy.get("input[data-testid='title']").clear()
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
 
     // Expect Info window should pop up
     cy.get("div[role=alert]").contains("An empty form cannot be saved.").should("be.visible")

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -24,19 +24,19 @@ describe("Home e2e", function () {
     cy.get("select[data-testid='descriptor.studyType']").select("Resequencing")
     cy.get("[data-testid='descriptor.studyAbstract']").type("Test abstract")
     // Save draft
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Fill a Policy form draft
     cy.clickAddObject(ObjectTypes.policy)
     cy.get("[data-testid='title']").type("Test Policy title")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Save another draft for later use
-    cy.formActions("New form")
+    cy.get("button").contains("Add policy").click()
     cy.get("input[data-testid='title']").type("Second test title")
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
 
     // Save submission and navigate to Home page

--- a/cypress/integration/objectLinksAttributes.spec.ts
+++ b/cypress/integration/objectLinksAttributes.spec.ts
@@ -19,7 +19,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='descriptor.studyAbstract']").type("Test abstract")
 
     // Add new Study Link
-    cy.get("div").contains("Study Links").parents().children("button").click()
+    cy.get("div[data-testid='studyLinks'] > div").children("button").click()
 
     // Choose XRef Link
     cy.get("select[data-testid='studyLinks.0']").select("XRef Link")
@@ -29,7 +29,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyLinks.0.label']").type("Test XRef Label")
 
     // URL Links
-    cy.get("div").contains("Study Links").parents().children("button").click()
+    cy.get("div[data-testid='studyLinks'] > div").children("button").click()
     cy.get("select[data-testid='studyLinks.1']").select("URL Link")
     cy.get("[data-testid='studyLinks.1.label']").type("Test URL Label")
 
@@ -41,7 +41,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyLinks.1.url']").clear().type("https://testlink.com").blur()
 
     // Add new Entrez Link
-    cy.get("div").contains("Study Links").parents().children("button").click()
+    cy.get("div[data-testid='studyLinks'] > div").children("button").click()
     cy.get("select[data-testid='studyLinks.2']").select("Entrez Link")
 
     cy.get("select[data-testid='studyLinks.2.entrezDb']").select("genome")
@@ -49,7 +49,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyLinks.2.label']").type("Test Entrez Label")
 
     // Choose Study Attributes
-    cy.get("div").contains("Study Attributes").parents().children("button").click()
+    cy.get("div[data-testid='studyAttributes'] > div").children("button").click()
 
     cy.get("[data-testid='studyAttributes.0.tag']").type("Test Attributes Tag")
     cy.get("[data-testid='studyAttributes.0.value']").type("Test Attributes Value")
@@ -82,7 +82,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyAttributes.0.tag']").should("have.value", "Test Attributes Tag")
     cy.get("[data-testid='studyAttributes.0.value']").should("have.value", "Test Attributes Value")
 
-    cy.get("div[data-testid='studyLinks'] > div", { timeout: 10000 }).should("have.length", 3)
+    cy.get("div[data-testid='studyLinks'] > div", { timeout: 10000 }).eq(1).children("div").should("have.length", 3)
     // Remove URL Link and check that the rest of the Study Links render correctly
     cy.wait(0)
     cy.get("[data-testid='studyLinks[1]'] > button", { timeout: 10000 }).should("be.visible").click()

--- a/cypress/integration/objectLinksAttributes.spec.ts
+++ b/cypress/integration/objectLinksAttributes.spec.ts
@@ -55,7 +55,7 @@ describe("render objects' links and attributes ", function () {
     cy.get("[data-testid='studyAttributes.0.value']").type("Test Attributes Value")
 
     // Save as draft
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("[data-testid='study-objects-list']").find("li").should("have.length", 1)
 
     // Check submitted object has correnct rendering data

--- a/cypress/integration/objectTitles.spec.ts
+++ b/cypress/integration/objectTitles.spec.ts
@@ -20,8 +20,7 @@ describe("draft and submitted objects' titles", function () {
     cy.get("[data-testid='descriptor.studyAbstract']").type("New abstract")
 
     // Submit form
-    cy.formActions("Submit")
-    cy.get(".MuiListItem-container", { timeout: 10000 }).should("have.length", 1)
+    cy.formActions("Mark as ready")
 
     // Check the submitted object has correct displayTitle
     cy.get("[data-testid='study-objects-list']").within(() => {
@@ -32,7 +31,7 @@ describe("draft and submitted objects' titles", function () {
     cy.editLatestSubmittedObject(ObjectTypes.study)
 
     cy.scrollTo("top")
-    cy.contains("Update Study", { timeout: 10000 }).should("be.visible")
+    cy.contains("Update", { timeout: 10000 }).should("be.visible")
     cy.get("@studyTitle", { timeout: 10000 }).should("have.value", "Test title")
     cy.get("@studyTitle", { timeout: 10000 }).type(" 2")
 
@@ -59,7 +58,7 @@ describe("draft and submitted objects' titles", function () {
     cy.get("input[data-testid='sampleName.taxonId']").type("123")
 
     // Save a draft
-    cy.formActions("Save as Draft")
+    cy.formActions("Save as draft")
     cy.get("div[role=alert]", { timeout: 10000 }).contains("Draft saved with")
     cy.get("[data-testid='sample-objects-list']").find("li").should("have.length", 1)
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -164,19 +164,17 @@ Cypress.Commands.add("formActions", buttonName => {
 Cypress.Commands.add("saveDoiForm", () => {
   cy.get("button").contains("Add DOI information (optional)").click()
   // Fill in required Creators field
-  cy.get("[data-testid='creators']").parent().children("button").click()
+  cy.get("div[data-testid='creators'] > div").children("button").click()
   cy.get("[data-testid='creators.0.givenName']", { timeout: 10000 }).type("Test given name")
   cy.get("[data-testid='creators.0.familyName']", { timeout: 10000 }).type("Test given name")
-  cy.get("[data-testid='creators.0.affiliation']", { timeout: 10000 }).parent().children("button").click()
+  cy.get("div[data-testid='creators.0.affiliation'] > div").children("button").click()
   cy.intercept("/organizations*").as("searchOrganization")
   cy.get("[data-testid='creators.0.affiliation.0.name-inputField']").type("csc")
   cy.wait("@searchOrganization")
-  cy.get(".MuiAutocomplete-option")
-    .should("be.visible")
-    .then($el => $el.first().click())
+  cy.get(".MuiAutocomplete-popper").should("be.visible").first().click()
   cy.get("[data-testid='creators.0.affiliation.0.schemeUri']").should("have.value", "https://ror.org")
   // Fill in required Subjects field
-  cy.get("[data-testid='subjects']").parent().children("button").click()
+  cy.get("div[data-testid='subjects'] > div").children("button").click()
   cy.get("select[data-testid='subjects.0.subject']", { timeout: 10000 }).select("FOS: Mathematics")
 
   // Fill in required Keywords

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -40,6 +40,7 @@ declare global {
       continueLatestDraft(objectType: string): Chainable<Element>
       openDOIForm(): Chainable<Element>
       formActions(buttonName: string): Chainable<Element>
+      optionsActions(optionName: string): Chainable<Element>
       saveDoiForm(): Chainable<Element>
       generateSubmissionAndObjects(stopToObjectType?: string): Chainable<Element>
       generateObject(objectType: string): Chainable<Element>
@@ -142,7 +143,7 @@ Cypress.Commands.add("editLatestSubmittedObject", objectType => {
     cy.get(`[data-testid='submitted-${objectType}-list-item']`).first().click()
   })
   cy.scrollTo("top")
-  cy.contains(`Update ${DisplayObjectTypes[objectType]}`, { timeout: 10000 }).should("be.visible")
+  cy.contains("Update", { timeout: 10000 }).should("be.visible")
 })
 
 // Go to DOI form
@@ -158,6 +159,11 @@ Cypress.Commands.add("formActions", buttonName => {
   cy.scrollTo("top")
   cy.get("button").contains(buttonName, { timeout: 10000 }).should("be.visible")
   cy.get("button").contains(buttonName, { timeout: 10000 }).click({ force: true })
+})
+
+Cypress.Commands.add("optionsActions", optionName => {
+  cy.get("[data-testid='MoreHorizIcon']", { timeout: 10000 }).click()
+  cy.contains(optionName).click()
 })
 
 // Fill required fields to submit DOI form
@@ -185,7 +191,8 @@ Cypress.Commands.add("saveDoiForm", () => {
 })
 
 // Method for hanlding request path when generating objects
-const addObjectPath = (objectType: string, submissionId: string) => `${baseUrl}objects/${objectType}?submission=${submissionId}`
+const addObjectPath = (objectType: string, submissionId: string) =>
+  `${baseUrl}objects/${objectType}?submission=${submissionId}`
 
 // Create objects from predefined templates
 // Possible to stop into specific object type. Add object type as argument

--- a/src/__tests__/FormAutocompleteField.test.tsx
+++ b/src/__tests__/FormAutocompleteField.test.tsx
@@ -46,6 +46,7 @@ describe("Test autocomplete on organisation field", () => {
       name: "Test name",
       published: false,
     },
+    openedXMLModal: false,
   })
 
   beforeAll(() => server.listen())

--- a/src/__tests__/WizardAddObjectStep.test.tsx
+++ b/src/__tests__/WizardAddObjectStep.test.tsx
@@ -40,6 +40,14 @@ describe("WizardAddObjectStep", () => {
         id: "FOL12341234",
         drafts: [{ accessionId: "TESTID1234", schema: ObjectTypes.study }],
       },
+      currentObject: {
+        accessionId: "TESTID0000",
+        tags: {
+          fileName: "Test XML file",
+          fileSize: 1,
+        },
+      },
+      openedXMLModal: false,
     })
     render(
       <MemoryRouter initialEntries={[{ pathname: "/submission", search: "step=1" }]}>
@@ -85,6 +93,14 @@ describe("WizardAddObjectStep", () => {
             published: false,
             drafts: [{ accessionId: "TESTID1234", schema: ObjectTypes.study }],
           },
+          currentObject: {
+            accessionId: "TESTID0000",
+            tags: {
+              fileName: "Test XML file",
+              fileSize: 1,
+            },
+          },
+          openedXMLModal: false,
         })
         render(
           <MemoryRouter initialEntries={[{ pathname: "/submission", search: "step=1" }]}>

--- a/src/__tests__/WizardJSONSchemaParser.test.tsx
+++ b/src/__tests__/WizardJSONSchemaParser.test.tsx
@@ -89,9 +89,6 @@ describe("Test form render by custom schema", () => {
           )
         }
 
-        // Most fields are rendered with labels. Test that label exists in form
-        if (source.properties) testLabels(source)
-
         // Loop through properties recursively
         if (source.properties) traverse(source, [...path, prop])
       }

--- a/src/__tests__/WizardShowSummaryStep.test.tsx
+++ b/src/__tests__/WizardShowSummaryStep.test.tsx
@@ -108,6 +108,7 @@ describe("WizardShowSummaryStep", () => {
         published: false,
         metadataObjects: submittedObjects,
         drafts: [],
+        openedXMLModal: true,
       },
     })
     wrapper = (

--- a/src/components/ErrorPageContainer.tsx
+++ b/src/components/ErrorPageContainer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react"
 
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined"
-import { CustomTheme } from "@mui/material"
+import { Theme } from "@mui/material"
 import Alert from "@mui/material/Alert"
 import Avatar from "@mui/material/Avatar"
 import Card from "@mui/material/Card"
@@ -22,7 +22,7 @@ type ErrorTypeProps = {
   errorType: string
 }
 
-const useStyles = makeStyles((theme: CustomTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   errorContainer: {
     width: "100%",
     marginTop: 10,

--- a/src/components/Home/UserDraftTemplateActions.tsx
+++ b/src/components/Home/UserDraftTemplateActions.tsx
@@ -22,7 +22,7 @@ const FormDialog = (props: { open: boolean; onClose: () => void }) => {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth={true}>
-      <WizardFillObjectDetailsForm closeDialog={onClose} />
+      <WizardFillObjectDetailsForm closeDialog={onClose} formRef={{ current: null }} />
     </Dialog>
   )
 }

--- a/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
@@ -1,41 +1,26 @@
 import React from "react"
 
-import Card from "@mui/material/Card"
-import { makeStyles } from "@mui/styles"
+import { styled } from "@mui/material/styles"
 
 import WizardFillObjectDetailsForm from "components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm"
-// import WizardUploadObjectXMLForm from "components/SubmissionWizard/WizardForms/WizardUploadObjectXMLForm"
 import WizardXMLObjectPage from "components/SubmissionWizard/WizardForms/WizardXMLObjectPage"
 import { ObjectSubmissionTypes } from "constants/wizardObject"
 import { useAppSelector } from "hooks"
 
-const useStyles = makeStyles(theme => ({
-  card: {
-    width: "100%",
-    padding: 0,
-    overflow: "visible",
-  },
-  submissionTypeButton: {
-    paddingTop: 2,
-    paddingBottom: 2,
-    marginLeft: 4,
-    marginRight: 4,
-  },
-  hideButton: {
-    color: theme.palette.common.white,
-    marginTop: 0,
-  },
+const StyledContent = styled("div")(() => ({
+  width: "100%",
+  padding: 0,
+  overflow: "visible",
 }))
 
 /*
  * Render correct form to add objects based on submission type in store
  */
 const WizardAddObjectCard: React.FC = () => {
-  const classes = useStyles()
   const submissionType = useAppSelector(state => state.submissionType)
   const objectType = useAppSelector(state => state.objectType)
 
-  const cards = {
+  const content = {
     [ObjectSubmissionTypes.form]: {
       component: <WizardFillObjectDetailsForm key={objectType + submissionType} />,
       testId: ObjectSubmissionTypes.form,
@@ -49,9 +34,9 @@ const WizardAddObjectCard: React.FC = () => {
   return (
     <>
       {submissionType && (
-        <Card className={classes.card} data-testid={cards[submissionType]["testId"]}>
-          {cards[submissionType]["component"]}
-        </Card>
+        <StyledContent data-testid={content[submissionType]["testId"]}>
+          {content[submissionType]["component"]}
+        </StyledContent>
       )}
     </>
   )

--- a/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
@@ -6,6 +6,7 @@ import WizardFillObjectDetailsForm from "components/SubmissionWizard/WizardForms
 import WizardXMLObjectPage from "components/SubmissionWizard/WizardForms/WizardXMLObjectPage"
 import { ObjectSubmissionTypes } from "constants/wizardObject"
 import { useAppSelector } from "hooks"
+import type { FormRef } from "types"
 
 const StyledContent = styled("div")(() => ({
   width: "100%",
@@ -16,13 +17,13 @@ const StyledContent = styled("div")(() => ({
 /*
  * Render correct form to add objects based on submission type in store
  */
-const WizardAddObjectCard: React.FC = () => {
+const WizardAddObjectCard = ({ formRef }: { formRef?: FormRef }) => {
   const submissionType = useAppSelector(state => state.submissionType)
   const objectType = useAppSelector(state => state.objectType)
 
   const content = {
     [ObjectSubmissionTypes.form]: {
-      component: <WizardFillObjectDetailsForm key={objectType + submissionType} />,
+      component: <WizardFillObjectDetailsForm key={objectType + submissionType} formRef={formRef} />,
       testId: ObjectSubmissionTypes.form,
     },
     [ObjectSubmissionTypes.xml]: {

--- a/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardAddObjectCard.tsx
@@ -4,14 +4,14 @@ import Card from "@mui/material/Card"
 import { makeStyles } from "@mui/styles"
 
 import WizardFillObjectDetailsForm from "components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm"
-import WizardUploadObjectXMLForm from "components/SubmissionWizard/WizardForms/WizardUploadObjectXMLForm"
+// import WizardUploadObjectXMLForm from "components/SubmissionWizard/WizardForms/WizardUploadObjectXMLForm"
+import WizardXMLObjectPage from "components/SubmissionWizard/WizardForms/WizardXMLObjectPage"
 import { ObjectSubmissionTypes } from "constants/wizardObject"
 import { useAppSelector } from "hooks"
 
 const useStyles = makeStyles(theme => ({
   card: {
     width: "100%",
-    marginBottom: 4,
     padding: 0,
     overflow: "visible",
   },
@@ -41,7 +41,7 @@ const WizardAddObjectCard: React.FC = () => {
       testId: ObjectSubmissionTypes.form,
     },
     [ObjectSubmissionTypes.xml]: {
-      component: <WizardUploadObjectXMLForm key={objectType + submissionType} />,
+      component: <WizardXMLObjectPage key={objectType + submissionType} />,
       testId: ObjectSubmissionTypes.xml,
     },
   }

--- a/src/components/SubmissionWizard/WizardComponents/WizardSavedObjectsList.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardSavedObjectsList.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { CustomTheme } from "@mui/material"
+import { Theme } from "@mui/material"
 import Box from "@mui/material/Box"
 import CardHeader from "@mui/material/CardHeader"
 import List from "@mui/material/List"
@@ -16,7 +16,7 @@ import { useAppSelector } from "hooks"
 import type { ObjectInsideSubmissionWithTags } from "types"
 import { getItemPrimaryText, formatDisplayObjectType } from "utils"
 
-const useStyles = makeStyles((theme: CustomTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   objectList: {
     flex: "auto",
   },

--- a/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
@@ -24,7 +24,9 @@ import { setObjectType, resetObjectType } from "features/wizardObjectTypeSlice"
 import { updateStep } from "features/wizardStepObjectSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import { useAppDispatch, useAppSelector } from "hooks"
-import { ObjectInsideSubmissionWithTags } from "types"
+import draftAPIService from "services/draftAPI"
+import objectAPIService from "services/objectAPI"
+import type { FormRef, ObjectInsideSubmissionWithTags } from "types"
 import { pathWithLocale } from "utils"
 
 const ActionButton = (props: { step: number; parent: string; buttonText: string; disabled: boolean }) => {
@@ -71,6 +73,7 @@ const ActionButton = (props: { step: number; parent: string; buttonText: string;
         navigate({ pathname: pathname, search: stepParam })
         dispatch(setSubmissionType(ObjectSubmissionTypes.form))
         dispatch(setObjectType(parent))
+        if (formRef?.current) formRef.current?.dispatchEvent(new Event("reset", { bubbles: true }))
       }
     }
   }
@@ -90,6 +93,8 @@ const ActionButton = (props: { step: number; parent: string; buttonText: string;
         variant="contained"
         onClick={() => handleClick()}
         sx={theme => ({ marginTop: theme.spacing(2.4) })}
+        form="hook-form"
+        type="reset"
       >
         {buttonText}
       </Button>
@@ -264,8 +269,9 @@ const WizardStep = (params: {
     objects?: { ready?: stepItemObject[]; drafts?: stepItemObject[] }
   }[]
   actionButtonText: string
+  formRef?: FormRef
 }) => {
-  const { step, stepItems, actionButtonText } = params
+  const { step, stepItems, actionButtonText, formRef } = params
   const submission = useAppSelector(state => state.submission)
   const currentStepObject = useAppSelector(state => state.stepObject)
   const singleObjectStepItems = [ObjectTypes.study]
@@ -320,6 +326,7 @@ const WizardStep = (params: {
                       : actionButtonText
                   }
                   disabled={hasObjects && singleObjectStepItems.indexOf(objectType) > -1}
+                  formRef={formRef}
                 />
               </ObjectWrapper>
             </ListItem>

--- a/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
@@ -187,7 +187,11 @@ const StepItems = (props: {
                         color: theme.palette.primary.main,
                       })}
                     >
-                      {item.displayTitle !== "" ? item.displayTitle : item.id}
+                      {item.objectData?.tags.submissionType === ObjectSubmissionTypes.xml
+                        ? item.objectData.tags.fileName
+                        : item.displayTitle !== ""
+                        ? item.displayTitle
+                        : item.id}
                     </Link>
                   </Grid>
                   <Grid item>

--- a/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
@@ -24,13 +24,17 @@ import { setObjectType, resetObjectType } from "features/wizardObjectTypeSlice"
 import { updateStep } from "features/wizardStepObjectSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import { useAppDispatch, useAppSelector } from "hooks"
-import draftAPIService from "services/draftAPI"
-import objectAPIService from "services/objectAPI"
 import type { FormRef, ObjectInsideSubmissionWithTags } from "types"
 import { pathWithLocale } from "utils"
 
-const ActionButton = (props: { step: number; parent: string; buttonText: string; disabled: boolean }) => {
-  const { step, parent, buttonText, disabled } = props
+const ActionButton = (props: {
+  step: number
+  parent: string
+  buttonText: string
+  disabled: boolean
+  formRef?: FormRef
+}) => {
+  const { step, parent, buttonText, disabled, formRef } = props
   const navigate = useNavigate()
   const submission = useAppSelector(state => state.submission)
   const formState = useAppSelector(state => state.submissionType)

--- a/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStep.tsx
@@ -162,7 +162,7 @@ const StepItems = (props: {
   }
 
   const ObjectItem = styled("div")(({ theme }) => ({
-    paddingTop: theme.spacing(3),
+    paddingTop: theme.spacing(2.5),
   }))
 
   return (
@@ -172,8 +172,8 @@ const StepItems = (props: {
           return (
             <Collapse component={"li"} key={item.id}>
               <ObjectItem>
-                <Grid container spacing={2} justifyContent="space-around">
-                  <Grid item xs={6}>
+                <Grid container justifyContent="space-between">
+                  <Grid item xs={6} display="flex" alignItems="center">
                     <Link
                       tabIndex={0} // "href with # target will cause Firefox to refresh the page"
                       onClick={() => handleClick(item)}

--- a/src/components/SubmissionWizard/WizardComponents/WizardStepContentHeader.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStepContentHeader.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+import CardHeader from "@mui/material/CardHeader"
+import { styled } from "@mui/material/styles"
+
+const StyledCardHeader = styled(CardHeader)(({ theme }) => ({
+  ...theme.wizard.cardHeader,
+  "& .MuiCardHeader-action": {
+    margin: "0 !important",
+  },
+}))
+
+const WizardStepContentHeader = ({ action }: { action?: React.ReactNode }) => <StyledCardHeader action={action} />
+
+export default WizardStepContentHeader

--- a/src/components/SubmissionWizard/WizardComponents/WizardStepper.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStepper.tsx
@@ -15,7 +15,7 @@ import WizardStep from "./WizardStep"
 import { resetObjectType } from "features/wizardObjectTypeSlice"
 import { resetStepObject, updateStep } from "features/wizardStepObjectSlice"
 import { useAppDispatch, useAppSelector } from "hooks"
-import type { Schema, FormRef } from "types"
+import type { FormRef } from "types"
 
 // Top & bottom borders for first and last disabled elements
 const AccordionWrapper = styled("div")(({ theme }) => ({
@@ -74,7 +74,7 @@ const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
  */
 
 const WizardStepper = ({ formRef }: { formRef?: FormRef }) => {
-  const objectsArray = useAppSelector(state => state.objectTypesArray)
+  const objectTypesArray = useAppSelector(state => state.objectTypesArray)
   const submission = useAppSelector(state => state.submission)
   const currentStepObject = useAppSelector(state => state.stepObject)
   const dispatch = useAppDispatch()

--- a/src/components/SubmissionWizard/WizardComponents/WizardStepper.tsx
+++ b/src/components/SubmissionWizard/WizardComponents/WizardStepper.tsx
@@ -15,6 +15,7 @@ import WizardStep from "./WizardStep"
 import { resetObjectType } from "features/wizardObjectTypeSlice"
 import { resetStepObject, updateStep } from "features/wizardStepObjectSlice"
 import { useAppDispatch, useAppSelector } from "hooks"
+import type { Schema, FormRef } from "types"
 
 // Top & bottom borders for first and last disabled elements
 const AccordionWrapper = styled("div")(({ theme }) => ({
@@ -72,8 +73,8 @@ const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
  * If createSubmissionForm is passed as reference it is used to trigger correct form when clicking next.
  */
 
-const WizardStepper = () => {
-  const objectTypesArray = useAppSelector(state => state.objectTypesArray)
+const WizardStepper = ({ formRef }: { formRef?: FormRef }) => {
+  const objectsArray = useAppSelector(state => state.objectTypesArray)
   const submission = useAppSelector(state => state.submission)
   const currentStepObject = useAppSelector(state => state.stepObject)
   const dispatch = useAppDispatch()
@@ -141,7 +142,12 @@ const WizardStepper = () => {
             </AccordionSummary>
             {step.stepItems && step.actionButtonText && (
               <AccordionDetails>
-                <WizardStep step={stepNumber} stepItems={step.stepItems} actionButtonText={step.actionButtonText} />
+                <WizardStep
+                  step={stepNumber}
+                  stepItems={step.stepItems}
+                  actionButtonText={step.actionButtonText}
+                  formRef={formRef}
+                />
               </AccordionDetails>
             )}
           </Accordion>

--- a/src/components/SubmissionWizard/WizardForms/WizardDOIForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardDOIForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react"
 
-import { CustomTheme } from "@mui/material"
+import { Theme } from "@mui/material"
 import { makeStyles } from "@mui/styles"
 import Ajv from "ajv"
 import { useForm, FormProvider } from "react-hook-form"
@@ -19,7 +19,7 @@ import schemaAPIService from "services/schemaAPI"
 import { DoiFormDetails, FormObject } from "types"
 import { dereferenceSchema } from "utils/JSONSchemaUtils"
 
-const useStyles = makeStyles((theme: CustomTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   form: { ...theme.form },
 }))
 

--- a/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState, useRef } from "react"
 import { Theme } from "@mui/material"
 import Alert from "@mui/material/Alert"
 import Button from "@mui/material/Button"
-// import CardHeader from "@mui/material/CardHeader"
 import CircularProgress from "@mui/material/CircularProgress"
 import Container from "@mui/material/Container"
 import LinearProgress from "@mui/material/LinearProgress"
@@ -31,7 +30,7 @@ import { setFileTypes } from "features/fileTypesSlice"
 import { updateStatus } from "features/statusMessageSlice"
 import { updateTemplateDisplayTitle } from "features/templateSlice"
 import { setCurrentObject, resetCurrentObject } from "features/wizardCurrentObjectSlice"
-import { deleteObjectFromFolder, replaceObjectInFolder } from "features/wizardSubmissionFolderSlice"
+import { deleteObjectFromSubmission, replaceObjectInSubmission } from "features/wizardSubmissionSlice"
 import { setXMLModalOpen, resetXMLModalOpen } from "features/wizardXMLModalSlice"
 import { useAppSelector, useAppDispatch } from "hooks"
 import objectAPIService from "services/objectAPI"
@@ -434,7 +433,7 @@ const FormContent = ({
   }
 
   const handleXMLModalOpen = () => {
-    dispatch(setXMLModalOpen(true))
+    dispatch(setXMLModalOpen())
   }
 
   return (

--- a/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from "react"
 
-import { CustomTheme } from "@mui/material"
+import { Theme } from "@mui/material"
 import Alert from "@mui/material/Alert"
 import Button from "@mui/material/Button"
-import CardHeader from "@mui/material/CardHeader"
+// import CardHeader from "@mui/material/CardHeader"
 import CircularProgress from "@mui/material/CircularProgress"
 import Container from "@mui/material/Container"
 import LinearProgress from "@mui/material/LinearProgress"
@@ -13,6 +13,7 @@ import { ApiResponse } from "apisauce"
 import { cloneDeep, set } from "lodash"
 import { useForm, FormProvider, FieldValues, Resolver, SubmitHandler } from "react-hook-form"
 
+import WizardStepContentHeader from "../WizardComponents/WizardStepContentHeader"
 import getLinkedDereferencedSchema from "../WizardHooks/WizardLinkedDereferencedSchemaHook"
 import saveDraftHook from "../WizardHooks/WizardSaveDraftHook"
 import submitObjectHook from "../WizardHooks/WizardSubmitObjectHook"
@@ -40,15 +41,16 @@ import type { SubmissionDetailsWithId, FormDataFiles, FormObject, ObjectDetails,
 import { getObjectDisplayTitle, getAccessionIds, getNewUniqueFileTypes } from "utils"
 import { dereferenceSchema } from "utils/JSONSchemaUtils"
 
-const useStyles = makeStyles((theme: CustomTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   container: {
     margin: 0,
     padding: 0,
   },
-  cardHeader: { ...theme.wizard.cardHeader, position: "sticky", top: theme.spacing(7.7), zIndex: 2 },
+  cardHeader: { ...theme.wizard.cardHeader },
   resetTopMargin: { top: "0 !important" },
   cardHeaderAction: {
     margin: "0 !important",
+    border: "1px solid red",
   },
   buttonGroup: {
     display: "grid",
@@ -150,12 +152,7 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
 
   return (
     <>
-      <CardHeader
-        classes={{
-          root: classes.cardHeader,
-          action: classes.cardHeaderAction,
-        }}
-        className={currentObject?.status === ObjectStatus.template ? classes.resetTopMargin : ""}
+      <WizardStepContentHeader
         action={currentObject?.status === ObjectStatus.template ? templateButtonGroup : buttonGroup}
       />
       <WizardOptions onClearForm={onClickClearForm} onOpenXMLModal={onOpenXMLModal} />

--- a/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
@@ -1,18 +1,12 @@
 import React, { useEffect, useState, useRef } from "react"
 
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz"
 import { CustomTheme } from "@mui/material"
 import Alert from "@mui/material/Alert"
 import Button from "@mui/material/Button"
 import CardHeader from "@mui/material/CardHeader"
 import CircularProgress from "@mui/material/CircularProgress"
 import Container from "@mui/material/Container"
-import IconButton from "@mui/material/IconButton"
 import LinearProgress from "@mui/material/LinearProgress"
-import Menu from "@mui/material/Menu"
-import MenuItem from "@mui/material/MenuItem"
-import Stack from "@mui/material/Stack"
-import Typography from "@mui/material/Typography"
 import { makeStyles } from "@mui/styles"
 import Ajv from "ajv"
 import { ApiResponse } from "apisauce"
@@ -25,6 +19,7 @@ import submitObjectHook from "../WizardHooks/WizardSubmitObjectHook"
 
 import { WizardAjvResolver } from "./WizardAjvResolver"
 import JSONSchemaParser from "./WizardJSONSchemaParser"
+import WizardOptions from "./WizardOptions"
 import WizardUploadXMLModal from "./WizardUploadXMLModal"
 
 import { ResponseStatus } from "constants/responseStatus"
@@ -42,7 +37,7 @@ import objectAPIService from "services/objectAPI"
 import schemaAPIService from "services/schemaAPI"
 import templateAPI from "services/templateAPI"
 import type { SubmissionDetailsWithId, FormDataFiles, FormObject, ObjectDetails, ObjectDisplayValues } from "types"
-import { getObjectDisplayTitle, formatDisplayObjectType, getAccessionIds, getNewUniqueFileTypes } from "utils"
+import { getObjectDisplayTitle, getAccessionIds, getNewUniqueFileTypes } from "utils"
 import { dereferenceSchema } from "utils/JSONSchemaUtils"
 
 const useStyles = makeStyles((theme: CustomTheme) => ({
@@ -101,7 +96,6 @@ type FormContentProps = {
 const CustomCardHeader = (props: CustomCardHeaderProps) => {
   const classes = useStyles()
   const {
-    objectType,
     currentObject,
     refForm,
     onClickClearForm,
@@ -150,7 +144,6 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
         form={refForm}
       >
         {currentObject?.status === ObjectStatus.submitted ? "Update" : "Mark as ready"}{" "}
-        {formatDisplayObjectType(objectType)}
       </Button>
     </div>
   )
@@ -165,71 +158,8 @@ const CustomCardHeader = (props: CustomCardHeaderProps) => {
         className={currentObject?.status === ObjectStatus.template ? classes.resetTopMargin : ""}
         action={currentObject?.status === ObjectStatus.template ? templateButtonGroup : buttonGroup}
       />
-      <Options onClearForm={onClickClearForm} onOpenXMLModal={onOpenXMLModal} />
+      <WizardOptions onClearForm={onClickClearForm} onOpenXMLModal={onOpenXMLModal} />
     </>
-  )
-}
-
-const options = ["Upload XML", "Clear form"]
-
-const Options = ({ onClearForm, onOpenXMLModal }: { onClearForm: () => void; onOpenXMLModal: () => void }) => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const handleClose = (e, option?: string) => {
-    setAnchorEl(null)
-    option === options[0] ? onOpenXMLModal() : null
-    option === options[1] ? onClearForm() : null
-  }
-  return (
-    <Stack direction="row" alignItems="center" justifyContent="flex-end" sx={{ mt: "4rem", pr: "6rem" }}>
-      <Typography variant="subtitle2" color="primary" fontWeight={700}>
-        Options
-      </Typography>
-      <IconButton
-        aria-label="options-button"
-        id="options-button"
-        aria-controls={open ? "options" : undefined}
-        aria-expanded={open ? "true" : undefined}
-        aria-haspopup="true"
-        onClick={handleClick}
-        color="primary"
-      >
-        <MoreHorizIcon fontSize="large" />
-      </IconButton>
-      <Menu
-        id="options"
-        MenuListProps={{
-          "aria-labelledby": "options-button",
-          style: { padding: 0, width: "17rem" },
-        }}
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        transformOrigin={{ horizontal: "right", vertical: "top" }}
-        anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-      >
-        {options.map(option => (
-          <MenuItem
-            key={option}
-            selected={option === "Upload XML"}
-            onClick={e => handleClose(e, option)}
-            sx={{
-              p: "1.2rem",
-              "&.Mui-selected": { backgroundColor: "primary.lighter", color: "primary.main" },
-              color: "secondary.main",
-              fontWeight: 700,
-            }}
-          >
-            {option}
-          </MenuItem>
-        ))}
-      </Menu>
-    </Stack>
   )
 }
 

--- a/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardFillObjectDetailsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react"
+import React, { useEffect, useState, useRef, RefObject } from "react"
 
 import { Theme } from "@mui/material"
 import Alert from "@mui/material/Alert"
@@ -36,7 +36,14 @@ import { useAppSelector, useAppDispatch } from "hooks"
 import objectAPIService from "services/objectAPI"
 import schemaAPIService from "services/schemaAPI"
 import templateAPI from "services/templateAPI"
-import type { SubmissionDetailsWithId, FormDataFiles, FormObject, ObjectDetails, ObjectDisplayValues } from "types"
+import type {
+  SubmissionDetailsWithId,
+  FormDataFiles,
+  FormObject,
+  ObjectDetails,
+  ObjectDisplayValues,
+  FormRef,
+} from "types"
 import { getObjectDisplayTitle, getAccessionIds, getNewUniqueFileTypes } from "utils"
 import { dereferenceSchema } from "utils/JSONSchemaUtils"
 
@@ -89,6 +96,7 @@ type FormContentProps = {
   submission: SubmissionDetailsWithId
   currentObject: ObjectDetails & { objectId: string; [key: string]: unknown }
   closeDialog: () => void
+  formRef?: FormRef
 }
 
 /*
@@ -212,6 +220,7 @@ const FormContent = ({
   submission,
   currentObject,
   closeDialog,
+  formRef,
 }: FormContentProps) => {
   const classes = useStyles()
   const dispatch = useAppDispatch()
@@ -436,6 +445,11 @@ const FormContent = ({
     dispatch(setXMLModalOpen())
   }
 
+  const handleReset = () => {
+    methods.reset({ undefined })
+    setCurrentObjectId(null)
+  }
+
   return (
     <FormProvider {...methods}>
       <CustomCardHeader
@@ -455,6 +469,8 @@ const FormContent = ({
         className={classes.formComponents}
         onChange={() => handleChange()}
         onSubmit={methods.handleSubmit(onSubmit)}
+        ref={formRef as RefObject<HTMLFormElement>}
+        onReset={handleReset}
       >
         <div>{JSONSchemaParser.buildFields(formSchema)}</div>
       </form>
@@ -465,8 +481,8 @@ const FormContent = ({
 /*
  * Container for json schema based form. Handles json schema loading, form rendering, form submitting and error/success alerts.
  */
-const WizardFillObjectDetailsForm = (props: { closeDialog?: () => void }) => {
-  const { closeDialog } = props
+const WizardFillObjectDetailsForm = (props: { closeDialog?: () => void; formRef?: FormRef }) => {
+  const { closeDialog, formRef } = props
   const classes = useStyles()
   const dispatch = useAppDispatch()
 
@@ -617,6 +633,7 @@ const WizardFillObjectDetailsForm = (props: { closeDialog?: () => void }) => {
         currentObject={currentObject}
         key={currentObject?.accessionId || submission.submissionId}
         closeDialog={closeDialog || (() => ({}))}
+        formRef={formRef}
       />
       {submitting && <LinearProgress />}
       <WizardUploadXMLModal

--- a/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -347,12 +347,13 @@ const DisplayDescription = ({ description, children }: { description: string; ch
     setIsReadMore(!isReadMore)
   }
 
-  const ReadmoreText = styled("span")(() => ({
+  const ReadmoreText = styled("span")(({ theme }) => ({
     fontWeight: 700,
     textDecoration: "underline",
     display: "block",
     marginTop: "0.5rem",
-    color: "#006778",
+    color: theme.palette.primary.main,
+    "&:hover": { cursor: "pointer" },
   }))
 
   return (

--- a/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -23,6 +23,7 @@ import FormHelperText from "@mui/material/FormHelperText"
 import Grid from "@mui/material/Grid"
 import IconButton from "@mui/material/IconButton"
 import Paper from "@mui/material/Paper"
+import Stack from "@mui/material/Stack"
 import { styled } from "@mui/material/styles"
 import { Variant } from "@mui/material/styles/createTypography"
 import TextField from "@mui/material/TextField"
@@ -62,7 +63,6 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     flexDirection: "row",
     alignItems: "baseline",
-    width: "100%",
     "& label": {
       marginRight: 0,
     },
@@ -230,8 +230,9 @@ const traverseFields = (
   switch (object.type) {
     case "object": {
       const properties = object.properties
+
       return (
-        <FormSection key={name} name={name} label={label} level={path.length + 4} description={description}>
+        <FormSection key={name} name={name} label={label} level={path.length} description={description}>
           {Object.keys(properties).map(propertyKey => {
             const property = properties[propertyKey] as FormObject
             const required = object?.else?.required ?? object.required
@@ -272,14 +273,16 @@ const traverseFields = (
       ) : name.includes("keywords") ? (
         <FormTagField key={name} name={name} label={label} required={required} description={description} />
       ) : (
-        <FormTextField
-          key={name}
-          name={name}
-          label={label}
-          required={required}
-          description={description}
-          nestedField={nestedField}
-        />
+        <FormSection key={name} name={name} label={""} level={path.length} description={""}>
+          <FormTextField
+            key={name}
+            name={name}
+            label={label}
+            required={required}
+            description={description}
+            nestedField={nestedField}
+          />
+        </FormSection>
       )
     }
     case "integer": {
@@ -345,24 +348,51 @@ type FormSectionProps = {
  */
 const FormSection = ({ name, label, level, children, description }: FormSectionProps & { description: string }) => {
   const classes = useStyles()
-
+  const heading = label ? (
+    <Grid item xs={12} md={4}>
+      <Paper
+        component={Stack}
+        square={true}
+        justifyContent="center"
+        alignItems={level === 1 ? "center" : "start"}
+        elevation={0}
+        sx={{
+          backgroundColor: level > 0 ? "primary.lighter" : "white",
+          height: "100%",
+          ml: "5rem",
+          mr: "3rem",
+        }}
+      >
+        <Typography
+          key={`${name}-header`}
+          variant={level > 0 ? "subtitle1" : (`h${level + 4}` as Variant)}
+          role="heading"
+          color="secondary"
+        >
+          {label}
+          {description && level === 1 && (
+            <FieldTooltip title={description} placement="top" arrow>
+              <HelpOutlineIcon className={classes.sectionTip} />
+            </FieldTooltip>
+          )}
+        </Typography>
+      </Paper>
+    </Grid>
+  ) : (
+    <Grid item xs={0} md={level === 1 ? 4 : 0} />
+  )
   return (
     <ConnectForm>
       {({ errors }: ConnectFormMethods) => {
         const error = get(errors, name)
         return (
-          <div>
-            <div key={`${name}-section`}>
-              <Typography key={`${name}-header`} variant={`h${level}` as Variant} role="heading" color="secondary">
-                {label}
-                {description && level == 2 && (
-                  <FieldTooltip title={description} placement="top" arrow>
-                    <HelpOutlineIcon className={classes.sectionTip} />
-                  </FieldTooltip>
-                )}
-              </Typography>
-              {children}
-            </div>
+          <>
+            <Grid container key={`${name}-section`} spacing={0}>
+              {heading}
+              <Grid item xs={12} md={level > 0 ? 8 : 12}>
+                {children}
+              </Grid>
+            </Grid>
             <div>
               {error ? (
                 <FormControl error>
@@ -372,7 +402,7 @@ const FormSection = ({ name, label, level, children, description }: FormSectionP
                 </FormControl>
               ) : null}
             </div>
-          </div>
+          </>
         )
       }}
     </ConnectForm>

--- a/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardJSONSchemaParser.tsx
@@ -1400,7 +1400,7 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
               }
 
               return (
-                <div className={classes.divBaseline}>
+                <BaselineDiv>
                   <input
                     {...field}
                     required={required}
@@ -1443,7 +1443,7 @@ const FormTagField = ({ name, label, required, description }: FormFieldBaseProps
                       <TooltipIcon />
                     </FieldTooltip>
                   )}
-                </div>
+                </BaselineDiv>
               )
             }}
           />

--- a/src/components/SubmissionWizard/WizardForms/WizardOptions.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardOptions.tsx
@@ -1,0 +1,73 @@
+import React from "react"
+
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz"
+import IconButton from "@mui/material/IconButton"
+import Menu from "@mui/material/Menu"
+import MenuItem from "@mui/material/MenuItem"
+import Stack from "@mui/material/Stack"
+import Typography from "@mui/material/Typography"
+
+const options = ["Upload XML", "Clear form"]
+
+const WizardOptions = ({ onClearForm, onOpenXMLModal }: { onClearForm: () => void; onOpenXMLModal: () => void }) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = (e, option?: string) => {
+    setAnchorEl(null)
+    option === options[0] ? onOpenXMLModal() : null
+    option === options[1] ? onClearForm() : null
+  }
+  return (
+    <Stack direction="row" alignItems="center" justifyContent="flex-end" sx={{ mt: "4rem", pr: "6rem" }}>
+      <Typography variant="subtitle2" color="primary" fontWeight={700}>
+        Options
+      </Typography>
+      <IconButton
+        aria-label="options-button"
+        id="options-button"
+        aria-controls={open ? "options" : undefined}
+        aria-expanded={open ? "true" : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+        color="primary"
+      >
+        <MoreHorizIcon fontSize="large" />
+      </IconButton>
+      <Menu
+        id="options"
+        MenuListProps={{
+          "aria-labelledby": "options-button",
+          style: { padding: 0, width: "17rem" },
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        transformOrigin={{ horizontal: "right", vertical: "top" }}
+        anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+      >
+        {options.map(option => (
+          <MenuItem
+            key={option}
+            selected={option === "Upload XML"}
+            onClick={e => handleClose(e, option)}
+            sx={{
+              p: "1.2rem",
+              "&.Mui-selected": { backgroundColor: "primary.lighter", color: "primary.main" },
+              color: "secondary.main",
+              fontWeight: 700,
+            }}
+          >
+            {option}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Stack>
+  )
+}
+
+export default WizardOptions

--- a/src/components/SubmissionWizard/WizardForms/WizardUploadObjectXMLForm.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardUploadObjectXMLForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react"
 
-import { CustomTheme } from "@mui/material"
+import { Theme } from "@mui/material"
 import Alert from "@mui/material/Alert"
 import Button from "@mui/material/Button"
 import CardHeader from "@mui/material/CardHeader"
@@ -23,7 +23,7 @@ import { useAppSelector, useAppDispatch } from "hooks"
 import objectAPIService from "services/objectAPI"
 import xmlSubmissionAPIService from "services/xmlSubmissionAPI"
 
-const useStyles = makeStyles((theme: CustomTheme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   container: {
     padding: 0,
   },

--- a/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
@@ -19,12 +19,12 @@ import { setLoading, resetLoading } from "features/loadingSlice"
 import { resetStatusDetails, updateStatus } from "features/statusMessageSlice"
 import { setCurrentObject } from "features/wizardCurrentObjectSlice"
 import { setObjectType } from "features/wizardObjectTypeSlice"
-import { addObject, replaceObjectInFolder } from "features/wizardSubmissionFolderSlice"
+import { addObject, replaceObjectInSubmission } from "features/wizardSubmissionSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import { resetXMLModalOpen } from "features/wizardXMLModalSlice"
 import { useAppDispatch, useAppSelector } from "hooks"
 import objectAPIService from "services/objectAPI"
-import submissionAPIService from "services/submissionAPI"
+import xmlSubmissionAPIService from "services/xmlSubmissionAPI"
 import { ObjectDetails, ObjectTags } from "types"
 
 type WizardUploadXMLModalProps = {
@@ -67,7 +67,7 @@ const StyledButton = styled(Button)(() => ({
 const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUploadXMLModalProps) => {
   const dispatch = useAppDispatch()
   const objectType = useAppSelector(state => state.objectType)
-  const { folderId } = useAppSelector(state => state.submissionFolder)
+  const { submissionId } = useAppSelector(state => state.submission)
   const loading = useAppSelector(state => state.loading)
 
   const {
@@ -95,12 +95,11 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
 
         if (response.ok) {
           dispatch(
-            replaceObjectInFolder(
+            replaceObjectInSubmission(
               currentObject.accessionId,
               {
                 submissionType: ObjectSubmissionTypes.xml,
                 fileName: file.name,
-                displayTitle: file.name,
                 fileSize: file.size,
               },
               ObjectStatus.submitted
@@ -114,7 +113,6 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
               tags: {
                 submissionType: ObjectSubmissionTypes.xml,
                 fileName: file.name,
-                displayTitle: file.name,
                 fileSize: file.size,
               },
             })
@@ -124,7 +122,7 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
           dispatch(updateStatus({ status: ResponseStatus.error, response: response }))
         }
       } else {
-        const response = await objectAPIService.createFromXML(objectType, folderId, file)
+        const response = await objectAPIService.createFromXML(objectType, submissionId, file)
 
         if (response.ok) {
           dispatch(updateStatus({ status: ResponseStatus.success, response: response }))
@@ -135,7 +133,6 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
               tags: {
                 submissionType: ObjectSubmissionTypes.xml,
                 fileName: file.name,
-                displayTitle: file.name,
                 fileSize: file.size,
               },
             })
@@ -149,7 +146,6 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
               tags: {
                 submissionType: ObjectSubmissionTypes.xml,
                 fileName: file.name,
-                displayTitle: file.name,
                 fileSize: file.size,
               },
             })
@@ -225,7 +221,7 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
                   isFile: value => value?.length > 0,
                   isXML: value => value[0]?.type === "text/xml",
                   isValidXML: async value => {
-                    const response = await submissionAPIService.validateXMLFile(objectType, value[0])
+                    const response = await xmlSubmissionAPIService.validateXMLFile(objectType, value[0])
                     if (!response.data.isValid) {
                       return `The file you attached is not valid ${objectType},
                       our server reported following error:
@@ -260,12 +256,9 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
             left="0"
             justifyContent="center"
             alignItems="center"
-            bgcolor="common.white"
+            bgcolor="rgba(0, 0, 0, 0.5)"
           >
             <CircularProgress />
-            <Typography variant="subtitle1" color="secondary" sx={{ mt: "2rem" }}>
-              Uploading file...
-            </Typography>
           </Stack>
         )}
       </StyledContainer>

--- a/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useEffect } from "react"
 
 import Alert from "@mui/material/Alert"
 import Button from "@mui/material/Button"
@@ -69,6 +69,12 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
   const objectType = useAppSelector(state => state.objectType)
   const { submissionId } = useAppSelector(state => state.submission)
   const loading = useAppSelector(state => state.loading)
+  const focusTarget = useRef<HTMLButtonElement | null>(null)
+  const shouldFocus = useAppSelector(state => state.focus)
+
+  useEffect(() => {
+    if (shouldFocus && focusTarget.current) focusTarget.current.focus()
+  }, [shouldFocus])
 
   const {
     register,
@@ -186,13 +192,7 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
   })
 
   return (
-    <Modal
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
-      {...getRootProps()}
-    >
+    <Modal open={open} onClose={handleClose} aria-labelledby="xml-modal" {...getRootProps()}>
       <StyledContainer>
         <Typography variant="h4" role="heading" color="secondary" sx={{ pb: "2.5rem", fontWeight: 700 }}>
           Upload XML File
@@ -203,6 +203,7 @@ const WizardUploadXMLModal = ({ open, handleClose, currentObject }: WizardUpload
               Drag and drop the file here or
             </Typography>
             <StyledButton
+              ref={focusTarget}
               variant="contained"
               color="primary"
               onClick={() => handleButton()}

--- a/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardUploadXMLModal.tsx
@@ -1,0 +1,209 @@
+import React, { useState } from "react"
+
+import Alert from "@mui/material/Alert"
+import Box from "@mui/material/Box"
+import Button from "@mui/material/Button"
+import Container from "@mui/material/Container"
+import FormControl from "@mui/material/FormControl"
+import Modal from "@mui/material/Modal"
+import { styled } from "@mui/material/styles"
+import Table from "@mui/material/Table"
+// import TableBody from "@mui/material/TableBody"
+import TableCell from "@mui/material/TableCell"
+import TableContainer from "@mui/material/TableContainer"
+import TableHead from "@mui/material/TableHead"
+import TableRow from "@mui/material/TableRow"
+import Typography from "@mui/material/Typography"
+import { useForm } from "react-hook-form"
+
+import { ResponseStatus } from "constants/responseStatus"
+import { ObjectSubmissionTypes } from "constants/wizardObject"
+import { resetFocus } from "features/focusSlice"
+import { setLoading, resetLoading } from "features/loadingSlice"
+import { resetStatusDetails, updateStatus } from "features/statusMessageSlice"
+import { addObject } from "features/wizardSubmissionFolderSlice"
+import { resetXMLModalOpen } from "features/wizardXMLModalSlice"
+import { useAppDispatch, useAppSelector } from "hooks"
+import objectAPIService from "services/objectAPI"
+import submissionAPIService from "services/submissionAPI"
+
+type WizardUploadXMLModalProps = {
+  open: boolean
+  handleClose: () => void
+}
+
+const StyledContainer = styled(Container)(({ theme }) => ({
+  position: "absolute",
+  backgroundColor: theme.palette.common.white,
+  top: "50%",
+  left: "50%",
+  width: "92rem",
+  height: "42rem",
+  padding: "5rem",
+  bgcolor: "white",
+  transform: "translate(-50%, -50%)",
+  borderRadius: "0.375rem",
+  boxShadow: "0 4px 4px 0 rgba(0,0,0,0.25)",
+}))
+
+const StyledFormControl = styled(FormControl)(({ theme }) => ({
+  width: "100%",
+  height: "14rem",
+  flexDirection: "row",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "4rem",
+  border: `1px solid ${theme.palette.secondary.light}`,
+}))
+
+const StyledButton = styled(Button)(() => ({
+  width: "17rem",
+  height: "5rem",
+}))
+
+const WizardUploadXMLModal = ({ open, handleClose }: WizardUploadXMLModalProps) => {
+  const dispatch = useAppDispatch()
+  const objectType = useAppSelector(state => state.objectType)
+  const { folderId } = useAppSelector(state => state.submissionFolder)
+  const [isSubmitting, setSubmitting] = useState(false)
+
+  const {
+    watch,
+    register,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm({ mode: "onChange" })
+
+  const resetForm = () => {
+    reset()
+  }
+
+  const watchFile = watch("fileUpload")
+
+  const fileName = watchFile && watchFile[0] ? watchFile[0].name : "No file name"
+  console.log("isSubmitting :>> ", isSubmitting)
+  type FileUpload = { fileUpload: FileList }
+  const onSubmit = async (data: FileUpload) => {
+    dispatch(resetStatusDetails())
+    setSubmitting(true)
+    dispatch(setLoading())
+    const file = data.fileUpload[0] || {}
+    const waitForServertimer = setTimeout(() => {
+      dispatch(updateStatus({ status: ResponseStatus.info }))
+    }, 5000)
+    const response = await objectAPIService.createFromXML(objectType, folderId, file)
+
+    if (response.ok) {
+      dispatch(updateStatus({ status: ResponseStatus.success, response: response }))
+      dispatch(
+        addObject({
+          accessionId: response.data.accessionId,
+          schema: objectType,
+          tags: { submissionType: ObjectSubmissionTypes.xml, fileName, displayTitle: fileName },
+        })
+      )
+      resetForm()
+    } else {
+      dispatch(updateStatus({ status: ResponseStatus.error, response: response }))
+    }
+    clearTimeout(waitForServertimer)
+    setSubmitting(false)
+    dispatch(resetLoading())
+  }
+
+  const handleButton = () => {
+    const fileSelect = document && document.getElementById("file-select-button")
+    if (fileSelect && fileSelect.click()) {
+      fileSelect.click()
+    }
+    dispatch(resetFocus())
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <StyledContainer>
+        <Typography variant="h4" role="heading" color="secondary" sx={{ pb: "2.5rem", fontWeight: 700 }}>
+          Upload XML File
+        </Typography>
+        <TableContainer component={Box}>
+          <Table>
+            <TableHead>
+              <TableRow
+                sx={theme => ({
+                  border: `1px solid ${theme.palette.secondary.light}`,
+                  "& th": {
+                    px: "3.2rem",
+                    py: "1.6rem",
+                    color: theme.palette.secondary.main,
+                  },
+                })}
+              >
+                <TableCell width={"25%"}>Name</TableCell>
+                <TableCell width={"25%"}>Size</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+          </Table>
+        </TableContainer>
+        <form onSubmit={handleSubmit(async data => onSubmit(data as FileUpload))}>
+          <StyledFormControl>
+            <Typography variant="body1" color="secondary">
+              Drag and drop the file here or
+            </Typography>
+            <StyledButton
+              variant="contained"
+              color="primary"
+              onClick={() => handleButton()}
+              onBlur={() => dispatch(resetFocus())}
+              sx={{ ml: "1rem" }}
+            >
+              Select file
+            </StyledButton>
+            <input
+              type="file"
+              id="file-select-button"
+              data-testid="xml-upload"
+              hidden
+              {...register("fileUpload", {
+                validate: {
+                  isFile: value => value.length > 0,
+                  isXML: value => value[0]?.type === "text/xml",
+                  isValidXML: async value => {
+                    const response = await submissionAPIService.validateXMLFile(objectType, value[0])
+
+                    if (!response.data.isValid) {
+                      return `The file you attached is not valid ${objectType},
+                      our server reported following error:
+                      ${response.data.detail.reason}.`
+                    }
+                  },
+                },
+              })}
+            />
+          </StyledFormControl>
+        </form>
+        <StyledButton
+          variant="outlined"
+          color="primary"
+          sx={{ border: "2px solid", mt: "2.5rem" }}
+          onClick={() => dispatch(resetXMLModalOpen())}
+        >
+          Cancel
+        </StyledButton>
+        <Box position="absolute" bottom="-30%" left="0" right="0">
+          {errors.fileUpload?.type === "isFile" && <Alert severity="error">Please attach a file.</Alert>}
+          {errors.fileUpload?.type === "isXML" && <Alert severity="error">Please attach an XML file.</Alert>}
+          {errors.fileUpload?.type === "isValidXML" && <Alert severity="error">{errors?.fileUpload?.message}</Alert>}
+        </Box>
+      </StyledContainer>
+    </Modal>
+  )
+}
+
+export default WizardUploadXMLModal

--- a/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+
+import { TableBody } from "@mui/material"
+import Box from "@mui/material/Box"
+import Button from "@mui/material/Button"
+import Container from "@mui/material/Container"
+import { styled } from "@mui/material/styles"
+import Table from "@mui/material/Table"
+import TableCell from "@mui/material/TableCell"
+import TableContainer from "@mui/material/TableContainer"
+import TableHead from "@mui/material/TableHead"
+import TableRow from "@mui/material/TableRow"
+import Typography from "@mui/material/Typography"
+
+// import { setCurrentObject } from "features/wizardCurrentObjectSlice"
+
+import WizardUploadXMLModal from "./WizardUploadXMLModal"
+
+import { setXMLModalOpen, resetXMLModalOpen } from "features/wizardXMLModalSlice"
+import { useAppDispatch, useAppSelector } from "hooks"
+
+const StyledContainer = styled(Container)(() => ({
+  padding: "4rem 6rem",
+}))
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  border: `1px solid ${theme.palette.secondary.lightest}`,
+  "& th, td": {
+    padding: "1.6rem 3.2rem",
+    color: theme.palette.secondary.main,
+  },
+}))
+
+const WizardXMLObjectPage = () => {
+  const dispatch = useAppDispatch()
+  const xmlObject = useAppSelector(state => state.currentObject)
+  const openedXMLModal = useAppSelector(state => state.openedXMLModal)
+
+  return (
+    <StyledContainer disableGutters>
+      <Typography variant="h4" role="heading" color="secondary" sx={{ pb: "2.5rem", fontWeight: 700 }}>
+        {xmlObject.tags?.displayTitle}
+      </Typography>
+      <TableContainer component={Box}>
+        <Table>
+          <TableHead>
+            <StyledTableRow>
+              <TableCell width={"25%"}>Name</TableCell>
+              <TableCell width={"25%"}>Size</TableCell>
+              <TableCell></TableCell>
+            </StyledTableRow>
+          </TableHead>
+          <TableBody>
+            <StyledTableRow>
+              <TableCell>{xmlObject.tags?.fileName}</TableCell>
+              <TableCell>{xmlObject.tags?.fileSize}</TableCell>
+              <TableCell>
+                <Button variant="outlined" onClick={() => dispatch(setXMLModalOpen(true))}>
+                  Replace
+                </Button>
+              </TableCell>
+            </StyledTableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <WizardUploadXMLModal
+        open={openedXMLModal}
+        handleClose={() => {
+          dispatch(resetXMLModalOpen())
+        }}
+        currentObject={xmlObject}
+      />
+    </StyledContainer>
+  )
+}
+
+export default WizardXMLObjectPage

--- a/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 
 import Box from "@mui/material/Box"
-// import CardHeader from "@mui/material/CardHeader"
 import Container from "@mui/material/Container"
 import Link from "@mui/material/Link"
 import { styled } from "@mui/material/styles"
@@ -59,10 +58,10 @@ const WizardXMLObjectPage = () => {
             <TableBody>
               <StyledTableRow>
                 <TableCell>{xmlObject.tags?.fileName}</TableCell>
-                <TableCell>{xmlObject.tags?.fileSize}</TableCell>
+                <TableCell>{xmlObject.tags?.fileSize || 1} B</TableCell>
                 <TableCell align="right">
                   <Link
-                    onClick={() => dispatch(setXMLModalOpen(true))}
+                    onClick={() => dispatch(setXMLModalOpen())}
                     sx={{ mr: "4rem", "&:hover": { cursor: "pointer" } }}
                   >
                     Replace

--- a/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
+++ b/src/components/SubmissionWizard/WizardForms/WizardXMLObjectPage.tsx
@@ -1,18 +1,19 @@
 import React from "react"
 
-import { TableBody } from "@mui/material"
 import Box from "@mui/material/Box"
-import Button from "@mui/material/Button"
+// import CardHeader from "@mui/material/CardHeader"
 import Container from "@mui/material/Container"
+import Link from "@mui/material/Link"
 import { styled } from "@mui/material/styles"
 import Table from "@mui/material/Table"
+import TableBody from "@mui/material/TableBody"
 import TableCell from "@mui/material/TableCell"
 import TableContainer from "@mui/material/TableContainer"
 import TableHead from "@mui/material/TableHead"
 import TableRow from "@mui/material/TableRow"
 import Typography from "@mui/material/Typography"
 
-// import { setCurrentObject } from "features/wizardCurrentObjectSlice"
+import WizardStepContentHeader from "../WizardComponents/WizardStepContentHeader"
 
 import WizardUploadXMLModal from "./WizardUploadXMLModal"
 
@@ -20,7 +21,8 @@ import { setXMLModalOpen, resetXMLModalOpen } from "features/wizardXMLModalSlice
 import { useAppDispatch, useAppSelector } from "hooks"
 
 const StyledContainer = styled(Container)(() => ({
-  padding: "4rem 6rem",
+  padding: "4rem 6rem !important",
+  height: "100%",
 }))
 
 const StyledTableRow = styled(TableRow)(({ theme }) => ({
@@ -29,6 +31,8 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
     padding: "1.6rem 3.2rem",
     color: theme.palette.secondary.main,
   },
+  "& th": { fontSize: "1.4rem" },
+  "& td": { fontSize: "1.6rem" },
 }))
 
 const WizardXMLObjectPage = () => {
@@ -37,40 +41,46 @@ const WizardXMLObjectPage = () => {
   const openedXMLModal = useAppSelector(state => state.openedXMLModal)
 
   return (
-    <StyledContainer disableGutters>
-      <Typography variant="h4" role="heading" color="secondary" sx={{ pb: "2.5rem", fontWeight: 700 }}>
-        {xmlObject.tags?.displayTitle}
-      </Typography>
-      <TableContainer component={Box}>
-        <Table>
-          <TableHead>
-            <StyledTableRow>
-              <TableCell width={"25%"}>Name</TableCell>
-              <TableCell width={"25%"}>Size</TableCell>
-              <TableCell></TableCell>
-            </StyledTableRow>
-          </TableHead>
-          <TableBody>
-            <StyledTableRow>
-              <TableCell>{xmlObject.tags?.fileName}</TableCell>
-              <TableCell>{xmlObject.tags?.fileSize}</TableCell>
-              <TableCell>
-                <Button variant="outlined" onClick={() => dispatch(setXMLModalOpen(true))}>
-                  Replace
-                </Button>
-              </TableCell>
-            </StyledTableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <WizardUploadXMLModal
-        open={openedXMLModal}
-        handleClose={() => {
-          dispatch(resetXMLModalOpen())
-        }}
-        currentObject={xmlObject}
-      />
-    </StyledContainer>
+    <>
+      <WizardStepContentHeader />
+      <StyledContainer disableGutters>
+        <Typography variant="h4" role="heading" color="secondary" sx={{ pb: "2.5rem", fontWeight: 700 }}>
+          {xmlObject.tags?.fileName}
+        </Typography>
+        <TableContainer component={Box}>
+          <Table>
+            <TableHead>
+              <StyledTableRow>
+                <TableCell width={"25%"}>Name</TableCell>
+                <TableCell width={"25%"}>Size</TableCell>
+                <TableCell></TableCell>
+              </StyledTableRow>
+            </TableHead>
+            <TableBody>
+              <StyledTableRow>
+                <TableCell>{xmlObject.tags?.fileName}</TableCell>
+                <TableCell>{xmlObject.tags?.fileSize}</TableCell>
+                <TableCell align="right">
+                  <Link
+                    onClick={() => dispatch(setXMLModalOpen(true))}
+                    sx={{ mr: "4rem", "&:hover": { cursor: "pointer" } }}
+                  >
+                    Replace
+                  </Link>
+                </TableCell>
+              </StyledTableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <WizardUploadXMLModal
+          open={openedXMLModal}
+          handleClose={() => {
+            dispatch(resetXMLModalOpen())
+          }}
+          currentObject={xmlObject}
+        />
+      </StyledContainer>
+    </>
   )
 }
 

--- a/src/components/SubmissionWizard/WizardHooks/WizardSaveDraftHook.tsx
+++ b/src/components/SubmissionWizard/WizardHooks/WizardSaveDraftHook.tsx
@@ -1,5 +1,5 @@
 import { ResponseStatus } from "constants/responseStatus"
-import { ObjectStatus } from "constants/wizardObject"
+import { ObjectStatus, ObjectSubmissionTypes } from "constants/wizardObject"
 import { resetDraftStatus } from "features/draftStatusSlice"
 import { setLoading, resetLoading } from "features/loadingSlice"
 import { updateStatus } from "features/statusMessageSlice"
@@ -29,7 +29,13 @@ const saveDraftHook = async (props: SaveDraftHookProps) => {
 
     if (response.ok) {
       dispatch(resetDraftStatus())
-      dispatch(replaceObjectInSubmission(accessionId, { displayTitle: draftDisplayTitle }, ObjectStatus.draft))
+      dispatch(
+        replaceObjectInSubmission(
+          accessionId,
+          { displayTitle: draftDisplayTitle, submissionType: ObjectSubmissionTypes.form },
+          ObjectStatus.draft
+        )
+      )
       dispatch(
         updateStatus({
           status: ResponseStatus.success,
@@ -64,7 +70,7 @@ const saveDraftHook = async (props: SaveDraftHookProps) => {
         addDraftObject({
           accessionId: response.data.accessionId,
           schema: "draft-" + objectType,
-          tags: { displayTitle: draftDisplayTitle },
+          tags: { displayTitle: draftDisplayTitle, submissionType: ObjectSubmissionTypes.form },
         })
       )
       dispatch(resetCurrentObject())

--- a/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
@@ -22,10 +22,6 @@ const useStyles = makeStyles(() => ({
       paddingTop: 0,
     },
   },
-  formBox: {
-    display: "flex",
-    justifyContent: "center",
-  },
   objectList: {
     width: "40%",
   },
@@ -41,25 +37,24 @@ const WizardAddObjectStep: React.FC = () => {
   const classes = useStyles()
   const objectType = useAppSelector(state => state.objectType)
   const loading = useAppSelector(state => state.loading)
+  const openedXMLModal = useAppSelector(state => state.openedXMLModal)
 
   return (
     <>
       <Grid container spacing={2} className={classes.gridContainer}>
         <Grid item xs={12}>
-          <div className={classes.formBox}>
-            {objectType === "" ? (
-              <div className={classes.objectInfo}>
-                <p>Add objects by clicking the name, then fill form or upload XML File.</p>
-                <p>You can also add objects and edit them after saving your draft.</p>
-              </div>
-            ) : (
-              <WizardAddObjectCard />
-            )}
-          </div>
+          {objectType === "" ? (
+            <div className={classes.objectInfo}>
+              <p>Add objects by clicking the name, then fill form or upload XML File.</p>
+              <p>You can also add objects and edit them after saving your draft.</p>
+            </div>
+          ) : (
+            <WizardAddObjectCard />
+          )}
         </Grid>
 
         <Grid item xs>
-          {loading && (
+          {!openedXMLModal && loading && (
             <Grid container justifyContent="center">
               <CircularProgress />
             </Grid>

--- a/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
@@ -5,12 +5,12 @@ import Grid from "@mui/material/Grid"
 import { makeStyles } from "@mui/styles"
 
 import WizardAddObjectCard from "../WizardComponents/WizardAddObjectCard"
-import WizardSavedObjectsList from "../WizardComponents/WizardSavedObjectsList"
 
 import { useAppSelector } from "hooks"
 
 const useStyles = makeStyles(() => ({
   gridContainer: {
+    margin: 0,
     width: "100%",
     "& > :first-child": {
       paddingLeft: 0,
@@ -40,9 +40,6 @@ const useStyles = makeStyles(() => ({
 const WizardAddObjectStep: React.FC = () => {
   const classes = useStyles()
   const objectType = useAppSelector(state => state.objectType)
-  const submission = useAppSelector(state => state.submission)
-  const submissions = submission?.metadataObjects?.filter((obj: { schema: string }) => obj.schema === objectType)
-  const draftObjects = submission?.drafts?.filter((obj: { schema: string }) => obj.schema === `draft-${objectType}`)
   const loading = useAppSelector(state => state.loading)
 
   return (
@@ -62,14 +59,6 @@ const WizardAddObjectStep: React.FC = () => {
         </Grid>
 
         <Grid item xs>
-          <Grid container spacing={0}>
-            <Grid item xs={12}>
-              {submissions?.length > 0 && <WizardSavedObjectsList objects={submissions} />}
-            </Grid>
-            <Grid item xs={12}>
-              {draftObjects?.length > 0 && <WizardSavedObjectsList objects={draftObjects} />}
-            </Grid>
-          </Grid>
           {loading && (
             <Grid container justifyContent="center">
               <CircularProgress />

--- a/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardAddObjectStep.tsx
@@ -7,6 +7,7 @@ import { makeStyles } from "@mui/styles"
 import WizardAddObjectCard from "../WizardComponents/WizardAddObjectCard"
 
 import { useAppSelector } from "hooks"
+import type { FormRef } from "types"
 
 const useStyles = makeStyles(() => ({
   gridContainer: {
@@ -33,7 +34,7 @@ const useStyles = makeStyles(() => ({
 /**
  * Show selection for object and submission types and correct form based on users choice.
  */
-const WizardAddObjectStep: React.FC = () => {
+const WizardAddObjectStep = ({ formRef }: { formRef?: FormRef }) => {
   const classes = useStyles()
   const objectType = useAppSelector(state => state.objectType)
   const loading = useAppSelector(state => state.loading)
@@ -49,7 +50,7 @@ const WizardAddObjectStep: React.FC = () => {
               <p>You can also add objects and edit them after saving your draft.</p>
             </div>
           ) : (
-            <WizardAddObjectCard />
+            <WizardAddObjectCard formRef={formRef} />
           )}
         </Grid>
 

--- a/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
@@ -30,14 +30,14 @@ const useStyles = makeStyles(theme => ({
     "& .MuiTextField-root": {
       margin: "1rem 0",
     },
-    padding: "2rem",
+    padding: "4rem",
   },
   submitButton: {
     marginTop: "2rem",
     padding: "1rem 5rem",
   },
   typeOfSubmissionRow: {
-    marginTop: theme.spacing(-1),
+    marginTop: theme.spacing(2),
   },
   typeOfSubmissionLabel: {
     background: theme.palette.background.default,
@@ -111,7 +111,7 @@ const CreateSubmissionForm = ({ createSubmissionFormRef }: { createSubmissionFor
         onSubmit={handleSubmit(async data => onSubmit(data as SubmissionDataFromForm))}
         ref={createSubmissionFormRef as RefObject<HTMLFormElement>}
       >
-        <Typography variant="h4" gutterBottom component="div" color="secondary">
+        <Typography variant="h4" gutterBottom component="div" color="secondary" fontWeight="700">
           Name your submission
         </Typography>
         <Controller

--- a/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
@@ -22,7 +22,7 @@ import { updateStep } from "features/wizardStepObjectSlice"
 import { createSubmission, updateSubmission } from "features/wizardSubmissionSlice"
 import { setSubmissionType } from "features/wizardSubmissionTypeSlice"
 import { useAppSelector, useAppDispatch } from "hooks"
-import type { SubmissionDataFromForm, CreateSubmissionFormRef } from "types"
+import type { SubmissionDataFromForm, FormRef } from "types"
 import { pathWithLocale } from "utils"
 
 const useStyles = makeStyles(theme => ({
@@ -54,7 +54,7 @@ const useStyles = makeStyles(theme => ({
 /**
  * Define React Hook Form for adding new submission. Ref is added to RHF so submission can be triggered outside this component.
  */
-const CreateSubmissionForm = ({ createSubmissionFormRef }: { createSubmissionFormRef: CreateSubmissionFormRef }) => {
+const CreateSubmissionForm = ({ createSubmissionFormRef }: { createSubmissionFormRef: FormRef }) => {
   const classes = useStyles()
   const dispatch = useAppDispatch()
   const projectId = useAppSelector(state => state.projectId)
@@ -187,7 +187,7 @@ const CreateSubmissionForm = ({ createSubmissionFormRef }: { createSubmissionFor
  * Show form to create submission as first step of new draft wizard
  */
 
-const WizardCreateSubmissionStep = ({ createSubmissionFormRef }: { createSubmissionFormRef: CreateSubmissionFormRef }) => (
+const WizardCreateSubmissionStep = ({ createSubmissionFormRef }: { createSubmissionFormRef: FormRef }) => (
   <>
     <CreateSubmissionForm createSubmissionFormRef={createSubmissionFormRef} />
   </>

--- a/src/features/wizardCurrentObjectSlice.tsx
+++ b/src/features/wizardCurrentObjectSlice.tsx
@@ -10,6 +10,7 @@ const initialObject = {
   status: "",
   title: "",
   submissionType: "",
+  fileSize: "",
   tags: {},
 }
 

--- a/src/features/wizardSubmissionSlice.tsx
+++ b/src/features/wizardSubmissionSlice.tsx
@@ -153,7 +153,7 @@ export const updateSubmission =
 export const replaceObjectInSubmission =
   (
     accessionId: string,
-    tags: { submissionType?: string; displayTitle?: string; fileName?: string },
+    tags: { submissionType?: string; displayTitle?: string; fileName?: string; fileSize?: number },
     objectStatus?: string
   ) =>
   (dispatch: (reducer: DispatchReducer) => void) => {

--- a/src/features/wizardXMLModalSlice.tsx
+++ b/src/features/wizardXMLModalSlice.tsx
@@ -6,7 +6,7 @@ const wizardXMLModalSlice = createSlice({
   name: "wizardXMLModal",
   initialState,
   reducers: {
-    setXMLModalOpen: (_state, action) => action.payload,
+    setXMLModalOpen: () => true,
     resetXMLModalOpen: () => initialState,
   },
 })

--- a/src/features/wizardXMLModalSlice.tsx
+++ b/src/features/wizardXMLModalSlice.tsx
@@ -1,0 +1,14 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = false
+
+const wizardXMLModalSlice = createSlice({
+  name: "wizardXMLModal",
+  initialState,
+  reducers: {
+    setXMLModalOpen: (_state, action) => action.payload,
+    resetXMLModalOpen: () => initialState,
+  },
+})
+export const { setXMLModalOpen, resetXMLModalOpen } = wizardXMLModalSlice.actions
+export default wizardXMLModalSlice.reducer

--- a/src/rootReducer.ts
+++ b/src/rootReducer.ts
@@ -22,6 +22,7 @@ import objectTypeReducer from "features/wizardObjectTypeSlice"
 import stepObjectReducer from "features/wizardStepObjectSlice"
 import submissionReducer from "features/wizardSubmissionSlice"
 import submissionTypeReducer from "features/wizardSubmissionTypeSlice"
+import wizardXMLModalReducer from "features/wizardXMLModalSlice"
 
 const rootReducer = combineReducers({
   locale: localeReducer,
@@ -46,6 +47,7 @@ const rootReducer = combineReducers({
   fileTypes: fileTypesReducer,
   openedDoiForm: openedDoiFormReducer,
   projectId: projectReducer,
+  openedXMLModal: wizardXMLModalReducer,
 })
 
 export type RootState = ReturnType<typeof rootReducer>

--- a/src/services/errorMonitor.ts
+++ b/src/services/errorMonitor.ts
@@ -7,7 +7,7 @@ export const errorMonitor = (res: APIResponse) => {
   if (!res.ok && !exceptionalCase) {
     switch (res.status) {
       case 400:
-        window.location.href = "/error400"
+        // window.location.href = "/error400"
         break
       case 401:
         window.location.href = "/error401"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -118,7 +118,7 @@ let CSCtheme = createTheme({
     MuiContainer: {
       styleOverrides: {
         root: {
-          padding: 0,
+          padding: "0 !important",
           fontSizeBreakpoints,
         },
       },
@@ -182,11 +182,10 @@ let CSCtheme = createTheme({
     cardHeader: {
       backgroundColor: palette.common.white,
       position: "sticky",
-      top: 8,
       zIndex: 2,
+      top: defaultTheme.spacing(7.7),
+      height: "8rem",
       borderBottom: `0.1rem solid ${palette.primary.light}`,
-      paddingTop: "1.5rem",
-      paddingBottom: "1.5rem",
     },
     objectListItem: {
       border: "none",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -180,10 +180,13 @@ let CSCtheme = createTheme({
   },
   wizard: {
     cardHeader: {
-      backgroundColor: palette.primary.main,
-      color: "#FFF",
-      fontWeight: "bold",
-      minHeight: defaultTheme.spacing(6.875),
+      backgroundColor: palette.common.white,
+      position: "sticky",
+      top: 8,
+      zIndex: 2,
+      borderBottom: `0.1rem solid ${palette.primary.light}`,
+      paddingTop: "1.5rem",
+      paddingBottom: "1.5rem",
     },
     objectListItem: {
       border: "none",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -194,14 +194,7 @@ let CSCtheme = createTheme({
       padding: defaultTheme.spacing(1, 0, 1, 2),
     },
   },
-  tooltip: {
-    padding: "2rem 1rem",
-    backgroundColor: palette.common.white,
-    color: palette.secondary.main,
-    fontSize: "1.4rem",
-    boxShadow: defaultTheme.shadows[1],
-    border: `0.1rem solid ${palette.primary.main}`,
-  },
+
   form: {
     "& .MuiTextField-root": {
       width: "70%",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -12,6 +12,7 @@ const palette = {
     // green colors
     main: "#006778",
     light: "#c2dbdf",
+    lighter: "#d8e8ea",
     lightest: "#e5eff1",
   },
   secondary: {
@@ -200,12 +201,11 @@ let CSCtheme = createTheme({
     boxShadow: defaultTheme.shadows[1],
   },
   form: {
-    margin: defaultTheme.spacing(3),
     "& .MuiTextField-root > .Mui-required": {
       color: palette.primary.main,
     },
     "& .MuiTextField-root": {
-      width: "48%",
+      width: "70%",
       margin: defaultTheme.spacing(1),
     },
     "& .MuiTypography-root": {
@@ -222,7 +222,6 @@ let CSCtheme = createTheme({
     },
     "& .array": {
       margin: defaultTheme.spacing(1),
-
       "& .arrayRow": {
         display: "flex",
         alignItems: "center",
@@ -235,7 +234,6 @@ let CSCtheme = createTheme({
       "& h2, h3, h4, h5, h6": {
         margin: defaultTheme.spacing(1, 0),
       },
-
       "& .MuiPaper-elevation2": {
         paddingRight: defaultTheme.spacing(1),
         marginBottom: defaultTheme.spacing(1),

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -67,7 +67,7 @@ let CSCtheme = createTheme({
     h1: { fontSize: "9.6rem" },
     h2: { fontSize: "6rem" },
     h3: { fontSize: "4.8rem" },
-    h4: { fontSize: "3.5rem" },
+    h4: { fontSize: "3.2rem" },
     h5: { fontSize: "2rem" },
     h6: { fontSize: "1.25rem" },
     subtitle1: { fontSize: "1.6rem" },
@@ -195,21 +195,18 @@ let CSCtheme = createTheme({
     },
   },
   tooltip: {
+    padding: "2rem 1rem",
     backgroundColor: palette.common.white,
-    color: palette.common.black,
+    color: palette.secondary.main,
     fontSize: "1.4rem",
     boxShadow: defaultTheme.shadows[1],
+    border: `0.1rem solid ${palette.primary.main}`,
   },
   form: {
-    "& .MuiTextField-root > .Mui-required": {
-      color: palette.primary.main,
-    },
     "& .MuiTextField-root": {
       width: "70%",
-      margin: defaultTheme.spacing(1),
     },
     "& .MuiTypography-root": {
-      margin: defaultTheme.spacing(1),
       fontWeight: "bold",
     },
     "& .MuiTypography-h2": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export type ObjectInsideSubmission = {
 export type ObjectTags = {
   submissionType?: string
   fileName?: string
+  fileSize?: string
   displayTitle?: string
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,8 +99,7 @@ export type SubmissionDataFromForm = {
 }
 
 export type SubmissionFolder = SubmissionDetailsWithId & { doiInfo: DoiFormDetails }
-
-export type CreateSubmissionFormRef = { current: HTMLElement | null } | undefined
+export type FormRef = { current: HTMLElement | null } | undefined
 
 export type StatusDetails = {
   status: string | null

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -29,13 +29,7 @@ declare module "@mui/material/styles" {
       cardHeader: Record<string, unknown>
       objectListItem: Record<string, unknown>
     }
-    tooltip: {
-      backgroundColor: string
-      color: string
-      fontSize: string
-      boxShadow: string
-      border: string
-    }
+
     form: Object
   }
 
@@ -66,14 +60,7 @@ declare module "@mui/material/styles" {
       cardHeader?: Record<string, unknown>
       objectListItem?: Record<string, unknown>
     }
-    tooltip?: {
-      padding: string
-      backgroundColor?: string
-      color?: string
-      fontSize?: string
-      boxShadow?: string
-      border?: string
-    }
+
     form?: Object
     props: Record<string, unknown>
   }

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -34,6 +34,7 @@ declare module "@mui/material/styles" {
       color: string
       fontSize: string
       boxShadow: string
+      border: string
     }
     form: Object
   }
@@ -47,6 +48,14 @@ declare module "@mui/material/styles" {
     error: {
       main: string
     }
+    palette: {
+      primary: {
+        main: string
+        light: string
+        lighter: string
+        lightest: string
+      }
+    }
     info: {
       main: string
     }
@@ -58,10 +67,12 @@ declare module "@mui/material/styles" {
       objectListItem?: Record<string, unknown>
     }
     tooltip?: {
+      padding: string
       backgroundColor?: string
       color?: string
       fontSize?: string
       boxShadow?: string
+      border?: string
     }
     form?: Object
     props: Record<string, unknown>

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,7 +1,7 @@
 import type {} from "@mui/x-data-grid/themeAugmentation"
 
 declare module "@mui/material/styles" {
-  interface CustomTheme extends Theme {
+  interface CustomTheme {
     typography: {
       fontFamily: string
       pxToRem: (px: number) => string
@@ -16,6 +16,7 @@ declare module "@mui/material/styles" {
       body1: { fontSize: string }
       body2: { fontSize: string }
     }
+    secondary: { main: string; light: string; lightest: string }
     spacing: (factor) => string
     error: {
       main: string
@@ -25,55 +26,41 @@ declare module "@mui/material/styles" {
     }
     success: { main: string }
     warning: { main: string }
+    components: {
+      wizard?: {
+        cardHeader?: Record<string, unknown>
+        objectListItem?: Record<string, unknown>
+      }
+    }
     wizard: {
       cardHeader: Record<string, unknown>
       objectListItem: Record<string, unknown>
     }
 
     form: Object
-  }
-
-  interface ThemeOptions {
-    typography: {
-      fontFamily: string
-      fontSize: number
-    }
-    spacing: (factor) => string
-    error: {
-      main: string
-    }
-    palette: {
-      primary: {
-        main: string
-        light: string
-        lighter: string
-        lightest: string
-      }
-    }
-    info: {
-      main: string
-    }
-    secondary: { main: string; light: string; lightest: string }
-    success: { main: string }
-    warning: { main: string }
-    wizard?: {
-      cardHeader?: Record<string, unknown>
-      objectListItem?: Record<string, unknown>
-    }
-
-    form?: Object
     props: Record<string, unknown>
   }
+
+  interface Theme extends CustomTheme {}
+  interface ThemeOptions extends CustomTheme {}
 }
 
 declare module "@mui/material/styles/createPalette" {
   interface Palette {
     third: { main: string }
     button: { edit: string; delete: string }
+    wizard?: {
+      cardHeader?: Record<string, unknown>
+      objectListItem?: Record<string, unknown>
+    }
   }
   interface PaletteOptions {
     third?: { main?: string }
     button?: { edit?: string; delete: string }
+    wizard?: {
+      cardHeader?: Record<string, unknown>
+      objectListItem?: Record<string, unknown>
+    }
   }
 
   interface PaletteColor {
@@ -87,6 +74,7 @@ declare module "@mui/private-theming" {
 
   interface DefaultTheme extends CustomTheme {}
 }
+
 import type { Theme } from "@mui/material/styles"
 
 declare module "@mui/styles/defaultTheme" {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -10,8 +10,6 @@ export const getObjectDisplayTitle = (objectType: string, cleanedValues: ObjectD
   switch (objectType) {
     case ObjectTypes.study:
       return cleanedValues.descriptor?.studyTitle || ""
-    case ObjectTypes.dac:
-      return cleanedValues.contacts?.find(contact => contact.mainContact)?.name || ""
     default:
       return cleanedValues.title || ""
   }
@@ -20,13 +18,7 @@ export const getObjectDisplayTitle = (objectType: string, cleanedValues: ObjectD
 // Get Primary text for displaying item's title
 export const getItemPrimaryText = (item: ObjectInsideSubmissionWithTags): string => {
   if (item.tags?.displayTitle) {
-    switch (item.schema) {
-      case ObjectTypes.dac:
-      case `draft-${ObjectTypes.dac}`:
-        return `Main Contact: ${item.tags.displayTitle}`
-      default:
-        return item.tags.displayTitle
-    }
+    return item.tags.displayTitle
   } else if (item.tags?.fileName) {
     return item.tags.fileName
   }

--- a/src/views/Submission.tsx
+++ b/src/views/Submission.tsx
@@ -7,7 +7,7 @@ import Paper from "@mui/material/Paper"
 import { makeStyles } from "@mui/styles"
 import { useNavigate, useParams } from "react-router-dom"
 
-import WizardFooter from "components/SubmissionWizard/WizardComponents/WizardFooter"
+// import WizardFooter from "components/SubmissionWizard/WizardComponents/WizardFooter"
 import WizardStepper from "components/SubmissionWizard/WizardComponents/WizardStepper"
 import WizardAddObjectStep from "components/SubmissionWizard/WizardSteps/WizardAddObjectStep"
 import WizardCreateSubmissionStep from "components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep"
@@ -23,15 +23,9 @@ import Page404 from "views/ErrorPages/Page404"
 
 const useStyles = makeStyles(theme => ({
   paper: {
-    alignItems: "stretch",
+    padding: 0,
   },
-  paperContent: {
-    padding: theme.spacing(2),
-    display: "flex",
-    alignItems: "flex-start",
-    justifyContent: "start",
-    flexDirection: "column",
-  },
+
   container: {
     flex: "1 0 auto",
     padding: 0,
@@ -40,13 +34,13 @@ const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(7.7),
     minHeight: "calc(100vh - 137px)",
     backgroundColor: theme.palette.background.default,
+    "& .MuiGrid-item": { paddingTop: 0 },
   },
   stepper: {
     paddingTop: "0 !important",
     backgroundColor: theme.palette.primary.main,
   },
   stepContent: {
-    paddingTop: `${theme.spacing(5)} !important`,
     paddingLeft: `${theme.spacing(5)} !important`,
   },
 }))
@@ -135,7 +129,7 @@ const SubmissionWizard: React.FC = () => {
         </Grid>
       </Grid>
 
-      <WizardFooter />
+      {/* <WizardFooter /> */}
     </Container>
   )
 }

--- a/src/views/Submission.tsx
+++ b/src/views/Submission.tsx
@@ -17,7 +17,7 @@ import { updateStatus } from "features/statusMessageSlice"
 import { setSubmission, resetSubmission } from "features/wizardSubmissionSlice"
 import { useAppDispatch } from "hooks"
 import submissionAPIService from "services/submissionAPI"
-import type { CreateSubmissionFormRef } from "types"
+import type { FormRef } from "types"
 import { useQuery, pathWithLocale } from "utils"
 import Page404 from "views/ErrorPages/Page404"
 
@@ -49,14 +49,14 @@ const useStyles = makeStyles(theme => ({
 /**
  * Return correct content for each step
  */
-const getStepContent = (wizardStep: number, createSubmissionFormRef: CreateSubmissionFormRef) => {
+const getStepContent = (wizardStep: number, createSubmissionFormRef: FormRef, objectFormRef: FormRef) => {
   switch (wizardStep) {
     case 1:
       return <WizardCreateSubmissionStep createSubmissionFormRef={createSubmissionFormRef} />
     case 2:
     case 3:
     case 4:
-      return <WizardAddObjectStep />
+      return <WizardAddObjectStep formRef={objectFormRef} />
     case 5:
       return <WizardShowSummaryStep />
     default:
@@ -114,17 +114,19 @@ const SubmissionWizard: React.FC = () => {
 
   const createSubmissionFormRef = useRef<null | (HTMLFormElement & { changeCallback: () => void })>(null)
 
+  const objectFormRef = useRef<null | (HTMLFormElement & { changeCallback: () => void })>(null)
+
   return (
     <Container maxWidth={false} className={classes.container} disableGutters>
       <Grid container className={classes.gridContainer}>
         <Grid item xs={3} className={classes.stepper}>
-          <WizardStepper />
+          <WizardStepper formRef={objectFormRef} />
         </Grid>
         <Grid item xs={9} className={classes.stepContent}>
           {isFetchingSubmission && submissionId && <LinearProgress />}
           {(!isFetchingSubmission || !submissionId) && (
             <Paper className={classes.paper} elevation={2}>
-              {getStepContent(wizardStep, createSubmissionFormRef)}
+              {getStepContent(wizardStep, createSubmissionFormRef, objectFormRef)}
             </Paper>
           )}
         </Grid>

--- a/src/views/Submission.tsx
+++ b/src/views/Submission.tsx
@@ -124,7 +124,7 @@ const SubmissionWizard: React.FC = () => {
           {isFetchingSubmission && submissionId && <LinearProgress />}
           {(!isFetchingSubmission || !submissionId) && (
             <Paper className={classes.paper} elevation={2}>
-              <div className={classes.paperContent}>{getStepContent(wizardStep, createSubmissionFormRef)}</div>
+              {getStepContent(wizardStep, createSubmissionFormRef)}
             </Paper>
           )}
         </Grid>

--- a/src/views/Submission.tsx
+++ b/src/views/Submission.tsx
@@ -7,7 +7,7 @@ import Paper from "@mui/material/Paper"
 import { makeStyles } from "@mui/styles"
 import { useNavigate, useParams } from "react-router-dom"
 
-// import WizardFooter from "components/SubmissionWizard/WizardComponents/WizardFooter"
+import WizardFooter from "components/SubmissionWizard/WizardComponents/WizardFooter"
 import WizardStepper from "components/SubmissionWizard/WizardComponents/WizardStepper"
 import WizardAddObjectStep from "components/SubmissionWizard/WizardSteps/WizardAddObjectStep"
 import WizardCreateSubmissionStep from "components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep"
@@ -22,10 +22,6 @@ import { useQuery, pathWithLocale } from "utils"
 import Page404 from "views/ErrorPages/Page404"
 
 const useStyles = makeStyles(theme => ({
-  paper: {
-    padding: 0,
-  },
-
   container: {
     flex: "1 0 auto",
     padding: 0,
@@ -42,6 +38,11 @@ const useStyles = makeStyles(theme => ({
   },
   stepContent: {
     paddingLeft: `${theme.spacing(5)} !important`,
+    paddingRight: `${theme.spacing(5)} !important`,
+  },
+  paper: {
+    padding: 0,
+    height: "100%",
   },
 }))
 
@@ -114,12 +115,12 @@ const SubmissionWizard: React.FC = () => {
   const createSubmissionFormRef = useRef<null | (HTMLFormElement & { changeCallback: () => void })>(null)
 
   return (
-    <Container maxWidth={false} className={classes.container}>
-      <Grid container spacing={2} className={classes.gridContainer}>
+    <Container maxWidth={false} className={classes.container} disableGutters>
+      <Grid container className={classes.gridContainer}>
         <Grid item xs={3} className={classes.stepper}>
           <WizardStepper />
         </Grid>
-        <Grid item xs={7} className={classes.stepContent}>
+        <Grid item xs={9} className={classes.stepContent}>
           {isFetchingSubmission && submissionId && <LinearProgress />}
           {(!isFetchingSubmission || !submissionId) && (
             <Paper className={classes.paper} elevation={2}>
@@ -129,7 +130,7 @@ const SubmissionWizard: React.FC = () => {
         </Grid>
       </Grid>
 
-      {/* <WizardFooter /> */}
+      <WizardFooter />
     </Container>
   )
 }


### PR DESCRIPTION
### Description

Introduced new structure of  **Form**, new way of showing **Tooltip** and new way to upload and show **XML File**.

### Related issues

Closes  https://github.com/CSCfi/metadata-submitter-frontend/issues/540, https://github.com/CSCfi/metadata-submitter-frontend/issues/541, https://github.com/CSCfi/metadata-submitter-frontend/issues/787

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made

- Converted the **Form** into new layout by mainly refactoring `FormSection`  in `WizardJSONSchemaParser.tsx`
- Remade **Tooltip** with reusable component `DisplayDescription`, limited the default description text length to 60 chars with option to **Read more/Expand** text
- Added **Options** including **Upload XML** and **Clear form** to **Form** 
- Changed form's action buttons to **Save as draft** and **Mark as ready**
- Added modal for selecting/drag-dropping XML file
- Added a new page for showing information of selected XML file
- Fixed a bug about refreshing and starting a new form whenever we click `Add <object>` button
- Update unit test for **Tooltip** 
- Update e2e tests for **Form**


### Testing

- [x] Unit Tests
- [x] Integration Tests


### Mentions

<!-- Shout outs to your friends that you made this happen or need help. -->
