### PR TITLE
Change http --> https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change url of ROR from http to https #813
 - Refactor **folder** -> **submission** #807
 - Renamed "NewDraft" to "Submission" to all existing components and routes and related tests.
 

--- a/src/__tests__/FormAutocompleteField.test.tsx
+++ b/src/__tests__/FormAutocompleteField.test.tsx
@@ -19,7 +19,7 @@ const mockStore = configureStore([])
 const mockOrganisations = [{ name: "Test Organisation" }, { name: "Mock Org" }]
 
 const server = setupServer(
-  rest.get("http://api.ror.org/organizations", (req, res, ctx) => {
+  rest.get("https://api.ror.org/organizations", (req, res, ctx) => {
     const searchTerm = req.url.searchParams.get("query") as string
     return res(ctx.json({ items: mockOrganisations.filter(item => item.name.toLowerCase().includes(searchTerm)) }))
   })

--- a/src/services/rorAPI.ts
+++ b/src/services/rorAPI.ts
@@ -4,7 +4,7 @@ import { errorMonitor } from "./errorMonitor"
 
 import { APIResponse } from "types"
 
-const api = create({ baseURL: "http://api.ror.org" })
+const api = create({ baseURL: "https://api.ror.org" })
 api.addMonitor(errorMonitor)
 
 const getOrganisations = async (searchTerm: string): Promise<APIResponse> => {


### PR DESCRIPTION
### Description

Changing `http` --> `https` for `api.ror.org` because the https://test-metadata.sd.csc.fi/ requires the request to be served over `https`

### Related issues

Fixes https://github.com/CSCfi/metadata-submitter-frontend/issues/810

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

- Change `http` --> `https`

### Testing

- I have tested directly on https://test-metadata.sd.csc.fi/ and it does work. Hopefully it will work in reality.


