### PR TITLE
Add DOI form with new API endpoint and modify patch submission

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,7 +22,7 @@ jobs:
           if [[ $BRANCH == master ]]; then
              echo "VERSION=master" >> $GITHUB_ENV
           else
-             echo "VERSION=refactor/patch-folder" >> $GITHUB_ENV
+             echo "VERSION=develop" >> $GITHUB_ENV
           fi
       - name: Clone backend
         uses: actions/checkout@v3

--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,7 +22,7 @@ jobs:
           if [[ $BRANCH == master ]]; then
              echo "VERSION=master" >> $GITHUB_ENV
           else
-             echo "VERSION=develop" >> $GITHUB_ENV
+             echo "VERSION=refactor/patch-folder" >> $GITHUB_ENV
           fi
       - name: Clone backend
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Modify Patch submission with only "name" and "description" #816
 - Modified Form layout, Tooltip and Upload XML according to new UI design #811
+
+  #### Changed
+
+  - Change the way to add DOI form to submission with new endpoint "/doi"
+
 - Change url of ROR from http to https #813
 - Refactor **folder** -> **submission** #807
 - Renamed "NewDraft" to "Submission" to all existing components and routes and related tests.

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -26,7 +26,7 @@ describe("Basic application flow", function () {
     /*
      * 2nd step, Study, DAC and Policy
      */
-
+    cy.get("h4").contains("Study").should("be.visible")
     // Try to send invalid form
     cy.formActions("Mark as ready")
 
@@ -78,16 +78,15 @@ describe("Basic application flow", function () {
       cy.get("a").contains("Test title").click()
     })
 
-    cy.get("[data-testid='contacts']").should("be.visible")
-    cy.get("input[data-testid='contacts.0.name']", { timeout: 1000 }).should("be.visible").click({ force: true })
-    cy.get("input[data-testid='contacts.0.name']").type(" edited")
-    cy.get("[data-testid='contacts.0.name']").should("have.value", "Test contact name edited")
+    cy.get("input[data-testid='title']").should("be.visible")
+    cy.get("input[data-testid='title']").type(" edited")
+    cy.get("input[data-testid='title']").should("have.value", "Test title edited")
 
     cy.formActions("Update")
 
     cy.get("div[role=alert]").contains("Object updated")
     cy.get("[data-testid='dac-objects-list']", { timeout: 10000 }).within(() => {
-      cy.get("a").contains("Test contact name edited").should("be.visible")
+      cy.get("a").contains("Test title edited").should("be.visible")
     })
 
     // Fill Policy form

--- a/cypress/integration/app.spec.ts
+++ b/cypress/integration/app.spec.ts
@@ -85,10 +85,10 @@ describe("Basic application flow", function () {
 
     cy.formActions("Update")
 
-    cy.get("[data-testid='dac-objects-list']").within(() => {
-      cy.contains("Test title").should("be.visible").click({ force: true })
+    cy.get("div[role=alert]").contains("Object updated")
+    cy.get("[data-testid='dac-objects-list']", { timeout: 10000 }).within(() => {
+      cy.get("a").contains("Test contact name edited").should("be.visible")
     })
-    cy.get("[data-testid='contacts.0.name']").should("have.value", "Test contact name edited")
 
     // Fill Policy form
     cy.clickAddObject(ObjectTypes.policy)

--- a/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
+++ b/src/components/SubmissionWizard/WizardSteps/WizardCreateSubmissionStep.tsx
@@ -78,9 +78,8 @@ const CreateSubmissionForm = ({ createSubmissionFormRef }: { createSubmissionFor
         : []
 
     if (submission && submission?.submissionId) {
-      dispatch(updateSubmission(submission.submissionId, Object.assign({ ...data, submission, selectedDraftsArray })))
+      dispatch(updateSubmission(submission.submissionId, Object.assign({ ...data, submission })))
         .then(() => {
-          dispatch(resetTemplateAccessionIds())
           dispatch(updateStatus({ status: ResponseStatus.success, helperText: "Submission updated" }))
         })
         .catch((error: string) => {

--- a/src/features/wizardSubmissionSlice.tsx
+++ b/src/features/wizardSubmissionSlice.tsx
@@ -113,35 +113,19 @@ export const createSubmission =
   }
 
 export const updateSubmission =
-  (
-    submissionId: string,
-    submissionDetails: SubmissionDataFromForm & { submission: { drafts: ObjectInsideSubmissionWithTags[] } } & {
-      selectedDraftsArray: Array<ObjectInsideSubmissionWithTags>
-    }
-  ) =>
+  (submissionId: string, submissionDetails: SubmissionDataFromForm & { submission: SubmissionDetailsWithId }) =>
   async (dispatch: (reducer: DispatchReducer) => void): Promise<APIResponse> => {
-    const { selectedDraftsArray } = submissionDetails
-    // Add templates as selectedDrafts to current drafts in case there is any
-    const updatedDrafts =
-      selectedDraftsArray.length > 0
-        ? submissionDetails.submission.drafts.concat(selectedDraftsArray)
-        : submissionDetails.submission.drafts
-
-    const updatedSubmission = extend(
-      { ...submissionDetails.submission },
-      { name: submissionDetails.name, description: submissionDetails.description, drafts: updatedDrafts }
-    )
-
-    const changes = [
-      { op: "add", path: "/name", value: submissionDetails.name },
-      { op: "add", path: "/description", value: submissionDetails.description },
-      { op: "add", path: "/drafts/-", value: updatedDrafts },
-    ]
-
-    const response = await submissionAPIService.patchSubmissionById(submissionId, changes)
+    const response = await submissionAPIService.patchSubmissionById(submissionId, {
+      name: submissionDetails.name,
+      description: submissionDetails.description,
+    })
 
     return new Promise((resolve, reject) => {
       if (response.ok) {
+        const updatedSubmission = extend(
+          { ...submissionDetails.submission },
+          { name: submissionDetails.name, description: submissionDetails.description }
+        )
         dispatch(setSubmission(updatedSubmission))
         resolve(response)
       } else {
@@ -238,8 +222,7 @@ export const addDoiInfoToSubmission =
       subjects: modifiedSubjects,
     })
 
-    const changes = [{ op: "add", path: "/doiInfo", value: modifiedDoiFormDetails }]
-    const response = await submissionAPIService.patchSubmissionById(submissionId, changes)
+    const response = await submissionAPIService.putDOIInfo(submissionId, modifiedDoiFormDetails)
 
     return new Promise((resolve, reject) => {
       if (response.ok) {

--- a/src/services/submissionAPI.ts
+++ b/src/services/submissionAPI.ts
@@ -16,8 +16,11 @@ const getSubmissionById = async (submissionId: string): Promise<APIResponse> => 
   return await api.get(`/${submissionId}`)
 }
 
-const patchSubmissionById = async (submissionId: string, changes: Record<string, unknown>[]): Promise<APIResponse> => {
-  return await api.patch(`/${submissionId}`, changes)
+const patchSubmissionById = async (
+  submissionId: string,
+  JSONContent: { name: string; description: string }
+): Promise<APIResponse> => {
+  return await api.patch(`/${submissionId}`, JSONContent)
 }
 
 const deleteSubmissionById = async (submissionId: string): Promise<APIResponse> => {
@@ -33,10 +36,15 @@ const getSubmissions = async (params: {
   return await api.get("", params)
 }
 
+const putDOIInfo = async (submissionId: string, doiFormDetails: Record<string, unknown>[]): Promise<APIResponse> => {
+  return await api.put(`${submissionId}/doi`, doiFormDetails)
+}
+
 export default {
   createNewSubmission,
   getSubmissionById,
   patchSubmissionById,
   deleteSubmissionById,
   getSubmissions,
+  putDOIInfo,
 }


### PR DESCRIPTION
### Description

-  Updating submission now only has `name` and `description` in its PATCH request payload
-  Saving DOI form now goes to a separate api endpoint `/doi`

### Related issues

Closes https://github.com/CSCfi/metadata-submitter-frontend/issues/799
Related back-end PRs: https://github.com/CSCfi/metadata-submitter/pull/423, https://github.com/CSCfi/metadata-submitter/pull/450

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

- Modified `patchSubmissionById` and  added `putDOIInfo` in `wizardSubmissionSlice.tsx`
- Removed **_drafts as templates array_** when updating a submission in `WizardCreateSubmissionStep`
- Changed e2e test in git backend branch to `refactor/patch-folder`
- Updated Changelog

### Testing

- [x] Current Unit Tests and Integration Tests

